### PR TITLE
Fix casing for component name

### DIFF
--- a/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
+++ b/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
@@ -125,7 +125,7 @@ describe('Preview Tests', () => {
                 return {
                     platform: 'android',
                     target: 'sfdxemu',
-                    componentName: 'mockcomponentname'
+                    componentname: 'mockcomponentname'
                 };
             }
         });
@@ -137,7 +137,7 @@ describe('Preview Tests', () => {
                 return {
                     platform: 'iOS',
                     target: 'sfdxsimulator',
-                    componentName: 'mockcomponentname'
+                    componentname: 'mockcomponentname'
                 };
             }
         });


### PR DESCRIPTION
Fix casing for component name to make unit test pass.