### PR TITLE
don't run setup for device list

### DIFF
--- a/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
+++ b/src/cli/commands/force/lightning/local/__tests__/setup.test.ts
@@ -6,6 +6,7 @@
  */
 import * as Config from '@oclif/config';
 import { Logger } from '@salesforce/core';
+import { CommandLineUtils } from '../../../../../../common/Common';
 import { SetupTestResult } from '../../../../../../common/Requirements';
 import Setup from '../setup';
 enum PlatformType {
@@ -38,7 +39,7 @@ describe('Setup Tests', () => {
         const mockCall = jest.fn(() => {
             return true;
         });
-        setup.validatePlatformValue = mockCall;
+        CommandLineUtils.platformFlagIsValid = mockCall;
         await setup.run();
         expect(mockCall).toHaveBeenCalledWith('ios');
     });

--- a/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
@@ -60,25 +60,6 @@ describe('List Tests', () => {
         expect(iOSListCommandBlockMock).toHaveBeenCalled();
     });
 
-    test('Checks that setup is invoked', async () => {
-        setupPlatformFlag('android');
-        const logger = new Logger('test-list');
-        setupLogger(logger);
-        await list.run();
-        expect(passedSetupMock).toHaveBeenCalled();
-    });
-
-    test('Device List should throw an error if setup fails', async () => {
-        setupPlatformFlag('android');
-        const logger = new Logger('test-list');
-        setupLogger(logger);
-        jest.spyOn(Setup.prototype, 'run').mockImplementation(failedSetupMock);
-        list.run().catch((error) => {
-            expect(error && error instanceof SfdxError).toBeTruthy();
-        });
-        expect(failedSetupMock).toHaveBeenCalled();
-    });
-
     test('Logger must be initialized and invoked', async () => {
         const logger = new Logger('test-list');
         setupLogger(logger);

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -44,27 +44,11 @@ export default class List extends Setup {
         this.logger.info(`Device List command invoked for ${platform}`);
 
         return new Promise<any>((resolve, reject) => {
-            super
-                .run() // run setup first
-                .then((result) => {
-                    this.logger.info(
-                        'Setup requirements met, continuing with device list'
-                    );
+            const deviceList = CommandLineUtils.platformFlagIsIOS(platform)
+                ? this.iOSDeviceList()
+                : this.androidDeviceList();
 
-                    const deviceList = CommandLineUtils.platformFlagIsIOS(
-                        platform
-                    )
-                        ? this.iOSDeviceList()
-                        : this.androidDeviceList();
-
-                    resolve(deviceList);
-                })
-                .catch((error) => {
-                    this.logger.warn(
-                        `Device list failed for ${platform}. Setup requirements have not been met.`
-                    );
-                    reject(error);
-                });
+            resolve(deviceList);
         });
     }
 

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -22,7 +22,7 @@ Messages.importMessagesDirectory(__dirname);
 // or any library that is using the messages framework can also be loaded this way.
 const messages = Messages.loadMessages('@salesforce/lwc-dev-mobile', 'device');
 
-export default class List extends Setup {
+export default class List extends SfdxCommand {
     public static description = messages.getMessage('commandDescription');
 
     public static readonly flagsConfig: FlagsConfig = {
@@ -42,6 +42,16 @@ export default class List extends Setup {
     public async run(): Promise<any> {
         const platform = this.flags.platform;
         this.logger.info(`Device List command invoked for ${platform}`);
+
+        if (!CommandLineUtils.platformFlagIsValid(platform)) {
+            return Promise.reject(
+                new SfdxError(
+                    messages.getMessage('error:invalidInputFlagsDescription'),
+                    'lwc-dev-mobile',
+                    this.examples
+                )
+            );
+        }
 
         return new Promise<any>((resolve, reject) => {
             const deviceList = CommandLineUtils.platformFlagIsIOS(platform)

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -38,8 +38,7 @@ export default class Setup extends SfdxCommand {
 
     public async run(): Promise<any> {
         await this.config.runHook('installserverplugin', { id: 'setup' });
-        const valid = this.validatePlatformValue(this.flags.platform);
-        if (!valid) {
+        if (!CommandLineUtils.platformFlagIsValid(this.flags.platform)) {
             return Promise.reject(
                 new SfdxError(
                     messages.getMessage('error:invalidInputFlagsDescription'),
@@ -71,13 +70,6 @@ export default class Setup extends SfdxCommand {
 
     public executeSetup(setup: BaseSetup): Promise<SetupTestResult> {
         return setup.executeSetup();
-    }
-
-    public validatePlatformValue(platform: string): boolean {
-        return (
-            CommandLineUtils.platformFlagIsIOS(platform) ||
-            CommandLineUtils.platformFlagIsAndroid(platform)
-        );
     }
 
     protected async init(): Promise<void> {

--- a/src/common/Common.ts
+++ b/src/common/Common.ts
@@ -55,4 +55,11 @@ export class CommandLineUtils {
         }
         return false;
     }
+
+    public static platformFlagIsValid(platformFlag: string) {
+        return (
+            CommandLineUtils.platformFlagIsIOS(platformFlag) ||
+            CommandLineUtils.platformFlagIsAndroid(platformFlag)
+        );
+    }
 }

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -80,18 +80,19 @@ export class XcodeUtils {
         IOSSimulatorDevice[]
     > {
         return new Promise(async (resolve, reject) => {
+            let devices: IOSSimulatorDevice[] = [];
             try {
                 const devicesCmd = `${XCRUN_CMD} simctl list --json devices available`;
                 const supportedRuntimes = await XcodeUtils.getSupportedRuntimes();
                 const { stdout } = await XcodeUtils.executeCommand(devicesCmd);
-                const sims = IOSSimulatorDevice.parseJSONString(
+                devices = IOSSimulatorDevice.parseJSONString(
                     stdout,
                     supportedRuntimes
                 );
-                return resolve(sims);
             } catch (runtimesError) {
-                return reject(runtimesError);
+                XcodeUtils.logger.warn(runtimesError);
             }
+            return resolve(devices);
         });
     }
 


### PR DESCRIPTION
Skip running the setup step for device list command. It now either returns an empty list (if something fails) or an enumerated list of available devices.