### PR TITLE
Fixes handling of Promise rejections

### DIFF
--- a/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
+++ b/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
@@ -50,13 +50,11 @@ describe('Preview Tests', () => {
         const logger = new Logger('test-preview');
         setupLogger(logger);
         const compPathCalValidationlMock = jest.fn(() => {
-            return true;
+            return Promise.resolve();
         });
-        preview.validateComponentNameValue = compPathCalValidationlMock;
+        preview.validateAdditionalInputs = compPathCalValidationlMock;
         await preview.run();
-        expect(compPathCalValidationlMock).toHaveBeenCalledWith(
-            'mockcomponentname'
-        );
+        expect(compPathCalValidationlMock).toHaveBeenCalled();
     });
 
     test('Checks that launch for target platform  for Android is invoked', async () => {


### PR DESCRIPTION
This PR handles the issue of unhandled rejections that may arise. All that was needed was a **return statement** in the **preview** command when it called `super.run()...` . However I took the liberty of rearranging the code a bit , by flattening the chain of calls. 