### PR TITLE
skip loading config file when targetting browser

### DIFF
--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -255,27 +255,23 @@ export default class Preview extends Setup {
             appConfig = configFile.getAppConfig(platform, targetApp);
         }
 
-        const launchArgs: LaunchArgument[] =
-            (appConfig && appConfig.launch_arguments) || [];
-
         if (CommandLineUtils.platformFlagIsIOS(this.flags.platform)) {
+            const config = appConfig && (appConfig as IOSAppPreviewConfig);
             return this.launchIOS(
                 device,
                 component,
                 projectDir,
                 targetApp,
-                launchArgs
+                config
             );
         } else {
             const config = appConfig && (appConfig as AndroidAppPreviewConfig);
-            const activity = (config && config.activity) || '';
             return this.launchAndroid(
                 device,
                 component,
                 projectDir,
                 targetApp,
-                launchArgs,
-                activity
+                config
             );
         }
     }
@@ -308,7 +304,7 @@ export default class Preview extends Setup {
         componentName: string,
         projectDir: string,
         targetApp: string,
-        targetAppArguments: LaunchArgument[]
+        appConfig: IOSAppPreviewConfig | undefined
     ): Promise<boolean> {
         const launcher = new IOSLauncher(deviceName);
 
@@ -316,7 +312,7 @@ export default class Preview extends Setup {
             componentName,
             projectDir,
             targetApp,
-            targetAppArguments
+            appConfig
         );
     }
 
@@ -325,8 +321,7 @@ export default class Preview extends Setup {
         componentName: string,
         projectDir: string,
         targetApp: string,
-        targetAppArguments: LaunchArgument[],
-        launchActivity: string
+        appConfig: AndroidAppPreviewConfig | undefined
     ): Promise<boolean> {
         const launcher = new AndroidLauncher(deviceName);
 
@@ -334,8 +329,7 @@ export default class Preview extends Setup {
             componentName,
             projectDir,
             targetApp,
-            targetAppArguments,
-            launchActivity
+            appConfig
         );
     }
 }

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -13,6 +13,7 @@ import { CommandLineUtils } from '../../../../../common/Common';
 import { IOSLauncher } from '../../../../../common/IOSLauncher';
 import {
     AndroidAppPreviewConfig,
+    IOSAppPreviewConfig,
     LaunchArgument
 } from '../../../../../common/PreviewConfigFile';
 import { PreviewUtils } from '../../../../../common/PreviewUtils';
@@ -240,9 +241,19 @@ export default class Preview extends Setup {
 
         const component = this.flags.componentname;
 
-        const configFilePath = path.resolve(configFileName);
-        const configFile = PreviewUtils.loadConfigFile(configFilePath);
-        const appConfig = configFile.getAppConfig(platform, targetApp);
+        let appConfig:
+            | IOSAppPreviewConfig
+            | AndroidAppPreviewConfig
+            | undefined;
+
+        if (
+            PreviewUtils.isTargetingBrowser(targetApp) === false &&
+            configFileName.trim().length > 0
+        ) {
+            const configFilePath = path.resolve(configFileName);
+            const configFile = PreviewUtils.loadConfigFile(configFilePath);
+            appConfig = configFile.getAppConfig(platform, targetApp);
+        }
 
         const launchArgs: LaunchArgument[] =
             (appConfig && appConfig.launch_arguments) || [];
@@ -256,14 +267,15 @@ export default class Preview extends Setup {
                 launchArgs
             );
         } else {
-            const config = appConfig as AndroidAppPreviewConfig;
+            const config = appConfig && (appConfig as AndroidAppPreviewConfig);
+            const activity = (config && config.activity) || '';
             return this.launchAndroid(
                 device,
                 component,
                 projectDir,
                 targetApp,
                 launchArgs,
-                config.activity
+                activity
             );
         }
     }

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -7,7 +7,7 @@
 import cli from 'cli-ux';
 import androidConfig from '../config/androidconfig.json';
 import { AndroidSDKUtils } from './AndroidUtils';
-import { LaunchArgument } from './PreviewConfigFile';
+import { AndroidAppPreviewConfig, LaunchArgument } from './PreviewConfigFile';
 import { PreviewUtils } from './PreviewUtils';
 
 export class AndroidLauncher {
@@ -21,8 +21,7 @@ export class AndroidLauncher {
         compName: string,
         projectDir: string,
         targetApp: string,
-        targetAppArguments: LaunchArgument[],
-        launchActivity: string
+        appConfig: AndroidAppPreviewConfig | undefined
     ): Promise<boolean> {
         const preferredPack = await AndroidSDKUtils.findRequiredEmulatorImages();
         const emuImage = preferredPack.platformEmulatorImage || 'default';
@@ -78,6 +77,12 @@ export class AndroidLauncher {
                     return AndroidSDKUtils.launchURLIntent(url, actualPort);
                 } else {
                     spinner.stop(`Launching App ${targetApp}`);
+
+                    const launchActivity =
+                        (appConfig && appConfig.activity) || '';
+
+                    const targetAppArguments: LaunchArgument[] =
+                        (appConfig && appConfig.launch_arguments) || [];
                     return AndroidSDKUtils.launchNativeApp(
                         compName,
                         projectDir,

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -8,7 +8,7 @@ import childProcess from 'child_process';
 import cli from 'cli-ux';
 import util from 'util';
 import { IOSUtils } from './IOSUtils';
-import { LaunchArgument } from './PreviewConfigFile';
+import { IOSAppPreviewConfig, LaunchArgument } from './PreviewConfigFile';
 import { PreviewUtils } from './PreviewUtils';
 const exec = util.promisify(childProcess.exec);
 
@@ -23,7 +23,7 @@ export class IOSLauncher {
         compName: string,
         projectDir: string,
         targetApp: string,
-        targetAppArguments: LaunchArgument[]
+        appConfig: IOSAppPreviewConfig | undefined
     ): Promise<boolean> {
         const availableDevices: string[] = await IOSUtils.getSupportedDevices();
         const supportedRuntimes: string[] = await IOSUtils.getSupportedRuntimes();
@@ -83,6 +83,8 @@ export class IOSLauncher {
                     const url = `http://localhost:3333/lwc/preview/${compPath}`;
                     return IOSUtils.launchURLInBootedSimulator(deviceUDID, url);
                 } else {
+                    const targetAppArguments: LaunchArgument[] =
+                        (appConfig && appConfig.launch_arguments) || [];
                     return IOSUtils.launchAppInBootedSimulator(
                         deviceUDID,
                         compName,

--- a/src/common/PreviewUtils.ts
+++ b/src/common/PreviewUtils.ts
@@ -14,9 +14,11 @@ export interface ValidationResult {
 }
 
 export class PreviewUtils {
+    private static NAMESPACE = 'com.salesforce.mobile-tooling';
+
     public static BROWSER_TARGET_APP = 'browser';
-    public static COMPONENT_NAME_ARG_PREFIX = 'componentname';
-    public static PROJECT_DIR_ARG_PREFIX = 'projectdir';
+    public static COMPONENT_NAME_ARG_PREFIX = `${PreviewUtils.NAMESPACE}.componentname`;
+    public static PROJECT_DIR_ARG_PREFIX = `${PreviewUtils.NAMESPACE}.projectdir`;
 
     public static isTargetingBrowser(targetApp: string): boolean {
         return (

--- a/src/common/PreviewUtils.ts
+++ b/src/common/PreviewUtils.ts
@@ -8,17 +8,17 @@ import Ajv from 'ajv';
 import fs from 'fs';
 import { PreviewConfigFile } from './PreviewConfigFile';
 
+const NAMESPACE = 'com.salesforce.mobile-tooling';
+
 export interface ValidationResult {
     errorMessage: string | null;
     passed: boolean;
 }
 
 export class PreviewUtils {
-    private static NAMESPACE = 'com.salesforce.mobile-tooling';
-
     public static BROWSER_TARGET_APP = 'browser';
-    public static COMPONENT_NAME_ARG_PREFIX = `${PreviewUtils.NAMESPACE}.componentname`;
-    public static PROJECT_DIR_ARG_PREFIX = `${PreviewUtils.NAMESPACE}.projectdir`;
+    public static COMPONENT_NAME_ARG_PREFIX = `${NAMESPACE}.componentname`;
+    public static PROJECT_DIR_ARG_PREFIX = `${NAMESPACE}.projectdir`;
 
     public static isTargetingBrowser(targetApp: string): boolean {
         return (


### PR DESCRIPTION
Don't attempt at loading and parsing a config file when targeting the mobile browser for previewing.