### PR TITLE
Add debug, error logging of all commands

### DIFF
--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -13,7 +13,7 @@ import { AndroidSDKUtils } from '../../../../../../common/AndroidUtils';
 import { CommandLineUtils } from '../../../../../../common/Common';
 import { IOSSimulatorDevice } from '../../../../../../common/IOSTypes';
 import { IOSUtils } from '../../../../../../common/IOSUtils';
-import Setup from '../setup';
+import { LoggerSetup } from '../../../../../../common/LoggerSetup';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
@@ -78,6 +78,7 @@ export default class List extends SfdxCommand {
         await super.init();
         const logger = await Logger.child('mobile:device:list', {});
         this.logger = logger;
+        await LoggerSetup.initializePluginLoggers();
     }
 
     private showDeviceList(list: any[]) {

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -4,12 +4,15 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+import util from 'util';
+
 import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
 import { Logger, Messages, SfdxError } from '@salesforce/core';
-import util from 'util';
+
 import { AndroidEnvironmentSetup } from '../../../../../common/AndroidEnvironmentSetup';
 import { CommandLineUtils } from '../../../../../common/Common';
 import { IOSEnvironmentSetup } from '../../../../../common/IOSEnvironmentSetup';
+import { LoggerSetup } from '../../../../../common/LoggerSetup';
 import { BaseSetup, SetupTestResult } from '../../../../../common/Requirements';
 
 // Initialize Messages with the current plugin directory
@@ -76,6 +79,7 @@ export default class Setup extends SfdxCommand {
         await super.init();
         const logger = await Logger.child('mobile:setup', {});
         this.logger = logger;
+        await LoggerSetup.initializePluginLoggers();
     }
 
     protected setup(): BaseSetup {

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -16,9 +16,10 @@ import { CommonUtils } from './CommonUtils';
 import { LaunchArgument } from './PreviewConfigFile';
 import { PreviewUtils } from './PreviewUtils';
 
-const execSync = childProcess.execSync;
 const spawn = childProcess.spawn;
 type StdioOptions = childProcess.StdioOptions;
+
+const LOGGER_NAME = 'force:lightning:mobile:android';
 
 export class AndroidSDKUtils {
     static get androidHome(): string {
@@ -73,10 +74,9 @@ export class AndroidSDKUtils {
     public static ADB_SHELL_COMMAND_VERSION =
         AndroidSDKUtils.ADB_SHELL_COMMAND + ' --version';
 
-    public static setLogger(logger: Logger) {
-        if (logger) {
-            AndroidSDKUtils.logger = logger;
-        }
+    public static async initializeLogger(): Promise<void> {
+        AndroidSDKUtils.logger = await Logger.child(LOGGER_NAME);
+        return Promise.resolve();
     }
 
     public static convertToUnixPath(dirPath: string): string {
@@ -135,11 +135,10 @@ export class AndroidSDKUtils {
                     if (idx !== -1) {
                         reject(new Error('unsupported Java version.'));
                     }
-                    if (error.status === 127) {
+                    if (error.status && error.status === 127) {
                         reject(
                             new Error(
-                                'SDK Manager not found. Expected at ' +
-                                    AndroidSDKUtils.ANDROID_SDK_MANAGER_CMD
+                                `SDK Manager not found. Expected at ${AndroidSDKUtils.ANDROID_SDK_MANAGER_CMD}`
                             )
                         );
                     }
@@ -218,7 +217,7 @@ export class AndroidSDKUtils {
         return new Promise((resolve, reject) => {
             let devices: AndroidVirtualDevice[] = [];
             try {
-                const result = execSync(
+                const result = AndroidSDKUtils.executeCommand(
                     AndroidSDKUtils.AVDMANAGER_COMMAND + ' list avd'
                 );
                 if (result) {
@@ -663,21 +662,23 @@ export class AndroidSDKUtils {
         });
     }
 
-    private static logger: Logger = new Logger(
-        'force:lightning:mobile:android'
-    );
+    private static logger: Logger = new Logger(LOGGER_NAME);
     private static DEFAULT_ADB_CONSOLE_PORT = 5554;
     private static packageCache: Map<string, AndroidPackage> = new Map();
+    private static toolsBinLocation: string;
 
     private static getToolsBin(): string {
-        let toolsLocation = AndroidSDKUtils.ANDROID_TOOLS_BIN;
-        if (
-            !fs.existsSync(toolsLocation) &&
-            fs.existsSync(AndroidSDKUtils.ANDROID_CMD_LINE_TOOLS_BIN)
-        ) {
-            toolsLocation = AndroidSDKUtils.ANDROID_CMD_LINE_TOOLS_BIN;
+        if (this.toolsBinLocation === undefined) {
+            this.toolsBinLocation = AndroidSDKUtils.ANDROID_TOOLS_BIN;
+            if (
+                !fs.existsSync(this.toolsBinLocation) &&
+                fs.existsSync(AndroidSDKUtils.ANDROID_CMD_LINE_TOOLS_BIN)
+            ) {
+                this.toolsBinLocation =
+                    AndroidSDKUtils.ANDROID_CMD_LINE_TOOLS_BIN;
+            }
         }
-        return toolsLocation;
+        return this.toolsBinLocation;
     }
 
     private static systemImagePath(

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -131,18 +131,17 @@ export class AndroidSDKUtils {
 
                     if (!AndroidSDKUtils.isJavaHomeSet()) {
                         reject(new Error('JAVA_HOME is not set.'));
-                    }
-                    if (idx !== -1) {
+                    } else if (idx !== -1) {
                         reject(new Error('unsupported Java version.'));
-                    }
-                    if (error.status && error.status === 127) {
+                    } else if (error.status && error.status === 127) {
                         reject(
                             new Error(
                                 `SDK Manager not found. Expected at ${AndroidSDKUtils.ANDROID_SDK_MANAGER_CMD}`
                             )
                         );
+                    } else {
+                        reject(error);
                     }
-                    reject(error.message);
                 });
         });
     }

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -6,17 +6,34 @@
  */
 import * as childProcess from 'child_process';
 
+import { Logger } from '@salesforce/core';
+
 const execSync = childProcess.execSync;
 const spawn = childProcess.spawn;
 type StdioOptions = childProcess.StdioOptions;
+
+const LOGGER_NAME = 'force:lightning:mobile:common';
+
 export class CommonUtils {
+    public static async initializeLogger(): Promise<void> {
+        CommonUtils.logger = await Logger.child(LOGGER_NAME);
+        return Promise.resolve();
+    }
+
     public static executeCommand(
         command: string,
         stdioOptions: StdioOptions = ['ignore', 'pipe', 'ignore']
     ): string {
-        return execSync(command, {
-            stdio: stdioOptions
-        }).toString();
+        CommonUtils.logger.debug(`Executing command: '${command}'.`);
+        try {
+            return execSync(command, {
+                stdio: stdioOptions
+            }).toString();
+        } catch (error) {
+            CommonUtils.logger.error(`Error executing command '${command}':`);
+            CommonUtils.logger.error(`${error}`);
+            throw error;
+        }
     }
 
     public static async isLwcServerPluginInstalled(): Promise<void> {
@@ -31,4 +48,6 @@ export class CommonUtils {
             }
         });
     }
+
+    private static logger: Logger = new Logger(LOGGER_NAME);
 }

--- a/src/common/LoggerSetup.ts
+++ b/src/common/LoggerSetup.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+import { AndroidSDKUtils } from './AndroidUtils';
+import { CommonUtils } from './CommonUtils';
+import { IOSUtils } from './IOSUtils';
+
+export class LoggerSetup {
+    public static async initializePluginLoggers(): Promise<void> {
+        await AndroidSDKUtils.initializeLogger();
+        await IOSUtils.initializeLogger();
+        await CommonUtils.initializeLogger();
+        return Promise.resolve();
+    }
+}


### PR DESCRIPTION
Added the following logging to all commands:

- Each command to be executed will be logged in full at the `DEBUG` log level.
- Each command resulting in an error will have its command and error logged at the `ERROR` level.

In addition, tied utility class loggers to the root logger associated with the plugin runs, necessary to get proper logging messages in the CLI.