### PR TITLE
use xcodebuild command to detect existence of a valid Xcode

### DIFF
--- a/messages/setup.json
+++ b/messages/setup.json
@@ -8,7 +8,7 @@
     "ios:reqs:macos:fulfilledMessage" : "Running macOS.",
     "ios:reqs:macos:unfulfilledMessage" : "You must be running macOS to install an iOS development environment: %s",
     "ios:reqs:xcode:title" : "Checking Xcode",
-    "ios:reqs:xcode:fulfilledMessage" : "Xcode installed. XCode library path: %s",
+    "ios:reqs:xcode:fulfilledMessage" : "Xcode installed: %s",
     "ios:reqs:xcode:unfulfilledMessage" : "Xcode is not installed or configured. %s",
     "ios:reqs:simulator:title" : "Checking Supported Simulator Runtime",
     "ios:reqs:simulator:fulfilledMessage" : "One or more supported simulator runtimes are configured for iOS: %s",

--- a/src/common/IOSEnvironmentSetup.ts
+++ b/src/common/IOSEnvironmentSetup.ts
@@ -91,21 +91,16 @@ export class IOSEnvironmentSetup extends BaseSetup {
     }
 
     public async isXcodeInstalled(): Promise<string> {
-        const xcodeSelectCommand: string = '/usr/bin/xcode-select -p';
+        const xcodeBuildCommand: string = 'xcodebuild -version';
         try {
             this.logger.info('Executing a check for Xcode environment');
             const { stdout, stderr } = await IOSEnvironmentSetup.executeCommand(
-                xcodeSelectCommand
+                xcodeBuildCommand
             );
             if (stdout) {
-                const developmentLibraryPath = `${stdout}`.trim();
+                const xcodeDetails = `${stdout}`.trim().replace(/\n/gi, ' ');
                 return new Promise<string>((resolve, reject) =>
-                    resolve(
-                        util.format(
-                            this.fulfilledMessage,
-                            developmentLibraryPath
-                        )
-                    )
+                    resolve(util.format(this.fulfilledMessage, xcodeDetails))
                 );
             } else {
                 return new Promise<string>((resolve, reject) =>

--- a/src/common/__tests__/IOSEnvironmentSetup.test.ts
+++ b/src/common/__tests__/IOSEnvironmentSetup.test.ts
@@ -94,9 +94,7 @@ describe('IOS Environment Setup tests', () => {
         );
         const setup = new IOSEnvironmentSetup(logger);
         await setup.isXcodeInstalled();
-        expect(myXcodeSelectMock).toHaveBeenCalledWith(
-            '/usr/bin/xcode-select -p'
-        );
+        expect(myXcodeSelectMock).toHaveBeenCalledWith('xcodebuild -version');
     });
 
     it('Should throw an error for unsupported Xcode Env', async () => {


### PR DESCRIPTION
Instead of relying on `xcode-select` this PR switches to using `xcodebuild` command to determine if a valid Xcode is installed (and this command returns some useful info when Xcode is or is not installed).