### PR TITLE
Dynamically determine server port

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,13 +11,9 @@
                 "-p",
                 "iOS",
                 "-n",
-                "HelloWorld",
+                "c/helloWorld",
                 "-t",
-                "sfdxdebug",
-                "-a",
-                "com.salesforce.AppArgTest",
-                "-f",
-                "myConfigFile.json"
+                "sfdxdebug"
             ]
         },
         {
@@ -30,13 +26,9 @@
                 "-p",
                 "android",
                 "-n",
-                "HelloWorld",
+                "c/helloWorld",
                 "-t",
-                "emu2",
-                "-a",
-                "com.example.appargtest",
-                "-f",
-                "myConfigFile.json"
+                "emu2"
             ]
         },
         {

--- a/messages/preview.json
+++ b/messages/preview.json
@@ -13,7 +13,7 @@
     "error:invalidConfigFile:missingDescription": "Invalid or missing configuration file %s",
     "error:invalidConfigFile:genericDescription": "Configuration file has an invalid format: %s\n%s",
     "error:invalidConfigFile:missingAppConfigDescription": "No configuration found for %s for platform %s",
-    "reqs:server:title" : "Checking whether LWC local server is running",
-    "reqs:server:fulfilledMessage" : "LWC local server is running on port %s.",
-    "reqs:server:unfulfilledMessage" : "LWC local server is not running."
+    "reqs:server:title" : "Checking whether local development server is running",
+    "reqs:server:fulfilledMessage" : "Local development server is running on port %s.",
+    "reqs:server:unfulfilledMessage" : "Local development server is not running."
  }

--- a/messages/preview.json
+++ b/messages/preview.json
@@ -12,5 +12,8 @@
     "error:invalidComponentNameFlagsDescription": "Invalid or missing component name.",
     "error:invalidConfigFile:missingDescription": "Invalid or missing configuration file %s",
     "error:invalidConfigFile:genericDescription": "Configuration file has an invalid format: %s\n%s",
-    "error:invalidConfigFile:missingAppConfigDescription": "No configuration found for %s for platform %s"
+    "error:invalidConfigFile:missingAppConfigDescription": "No configuration found for %s for platform %s",
+    "reqs:server:title" : "Checking whether LWC local server is running",
+    "reqs:server:fulfilledMessage" : "LWC local server is running on port %s.",
+    "reqs:server:unfulfilledMessage" : "LWC local server is not running."
  }

--- a/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
@@ -27,13 +27,6 @@ const passedSetupMock = jest.fn(() => {
     return Promise.resolve({ hasMetAllRequirements: true, tests: [] });
 });
 
-const failedSetupMock = jest.fn(() => {
-    return Promise.resolve({
-        hasMetAllRequirements: false,
-        tests: ['Mock Failure in tests!']
-    });
-});
-
 describe('List Tests', () => {
     let list: List;
 

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -13,7 +13,11 @@ import { AndroidEnvironmentSetup } from '../../../../../common/AndroidEnvironmen
 import { CommandLineUtils } from '../../../../../common/Common';
 import { IOSEnvironmentSetup } from '../../../../../common/IOSEnvironmentSetup';
 import { LoggerSetup } from '../../../../../common/LoggerSetup';
-import { BaseSetup, SetupTestResult } from '../../../../../common/Requirements';
+import {
+    BaseSetup,
+    Requirement,
+    SetupTestResult
+} from '../../../../../common/Requirements';
 
 // Initialize Messages with the current plugin directory
 Messages.importMessagesDirectory(__dirname);
@@ -38,6 +42,8 @@ export default class Setup extends SfdxCommand {
         `sfdx force:lightning:local:setup -p iOS`,
         `sfdx force:lightning:local:setup -p Android`
     ];
+
+    private setupSteps: BaseSetup | undefined;
 
     public async run(): Promise<any> {
         if (!CommandLineUtils.platformFlagIsValid(this.flags.platform)) {
@@ -81,13 +87,19 @@ export default class Setup extends SfdxCommand {
         await LoggerSetup.initializePluginLoggers();
     }
 
-    protected setup(): BaseSetup {
-        let setup: BaseSetup = ({} as any) as BaseSetup; // should not be the case due to prior validation.
-        if (CommandLineUtils.platformFlagIsAndroid(this.flags.platform)) {
-            setup = new AndroidEnvironmentSetup(this.logger);
-        } else if (CommandLineUtils.platformFlagIsIOS(this.flags.platform)) {
-            setup = new IOSEnvironmentSetup(this.logger);
+    protected addRequirements(reqs: Requirement[]) {
+        this.setup().addRequirements(reqs);
+    }
+
+    private setup(): BaseSetup {
+        if (!this.setupSteps) {
+            this.setupSteps = CommandLineUtils.platformFlagIsAndroid(
+                this.flags.platform
+            )
+                ? (this.setupSteps = new AndroidEnvironmentSetup(this.logger))
+                : (this.setupSteps = new IOSEnvironmentSetup(this.logger));
         }
-        return setup;
+
+        return this.setupSteps;
     }
 }

--- a/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
+++ b/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
@@ -21,10 +21,7 @@ const passedSetupMock = jest.fn(() => {
 });
 
 const failedSetupMock = jest.fn(() => {
-    return Promise.resolve({
-        hasMetAllRequirements: false,
-        tests: ['Mock Failure in tests!']
-    });
+    return Promise.reject(new SfdxError('Mock Failure in tests!'));
 });
 
 describe('Preview Tests', () => {
@@ -88,9 +85,13 @@ describe('Preview Tests', () => {
         const logger = new Logger('test-preview');
         setupLogger(logger);
         jest.spyOn(Setup.prototype, 'run').mockImplementation(failedSetupMock);
-        preview.run().catch((error) => {
-            expect(error && error instanceof SfdxError).toBeTruthy();
-        });
+
+        try {
+            await preview.run();
+        } catch (error) {
+            expect(error instanceof SfdxError).toBeTruthy();
+        }
+
         expect(failedSetupMock).toHaveBeenCalled();
     });
 
@@ -103,7 +104,7 @@ describe('Preview Tests', () => {
         });
         jest.spyOn(CommonUtils, 'executeCommand').mockImplementation(cmdMock);
         preview.isLwcServerRunning().catch((error) => {
-            expect(error && error instanceof SfdxError).toBeTruthy();
+            expect(typeof error === 'string').toBeTruthy();
         });
     });
 

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -130,7 +130,7 @@ export default class Preview extends Setup {
                             )
                         }
                     ];
-                    super.addRequirements(extraReqs);
+                    this.addRequirements(extraReqs);
                 }
                 return super.run();
             })

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -265,6 +265,16 @@ export default class Preview extends Setup {
             }
         }
 
+        if (
+            PreviewUtils.useLwcServerForPreviewing(
+                this.targetApp,
+                this.appConfig
+            )
+        ) {
+            const port = CommonUtils.getLwcServerPort();
+            this.serverPort = port ? port : CommonUtils.DEFAULT_LWC_SERVER_PORT;
+        }
+
         return Promise.resolve();
     }
 
@@ -279,18 +289,6 @@ export default class Preview extends Setup {
 
     public launchPreview(): Promise<boolean> {
         // At this point all of the inputs/parameters have been verified and parsed so we can just use them.
-
-        this.serverPort = '3333'; // default to port 3333
-
-        if (
-            PreviewUtils.isTargetingBrowser(this.targetApp) ||
-            (this.appConfig && this.appConfig.preview_server_enabled === true)
-        ) {
-            const port = CommonUtils.getLwcServerPort();
-            if (port) {
-                this.serverPort = port;
-            }
-        }
 
         let appBundlePath: string | undefined;
 

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -114,7 +114,8 @@ export default class Preview extends Setup {
                 // then validate setup requirements
                 if (
                     PreviewUtils.isTargetingBrowser(this.targetApp) ||
-                    this.appConfig?.preview_server_enabled === true
+                    (this.appConfig &&
+                        this.appConfig.preview_server_enabled === true)
                 ) {
                     const extraReqs: Requirement[] = [
                         {
@@ -283,7 +284,7 @@ export default class Preview extends Setup {
 
         if (
             PreviewUtils.isTargetingBrowser(this.targetApp) ||
-            this.appConfig?.preview_server_enabled === true
+            (this.appConfig && this.appConfig.preview_server_enabled === true)
         ) {
             const port = CommonUtils.getLwcServerPort();
             if (port) {

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -121,12 +121,17 @@ export default class Preview extends Setup {
             PreviewUtils.BROWSER_TARGET_APP
         );
 
+        const projectDir = CommandLineUtils.resolveFlag(
+            this.flags.projectdir,
+            process.cwd()
+        );
+
         const configFileName = CommandLineUtils.resolveFlag(
             this.flags.configfile,
             ''
         ).trim();
 
-        const configFilePath = path.resolve(configFileName);
+        const configFilePath = path.resolve(projectDir, configFileName);
 
         const hasConfigFile =
             configFilePath.length > 0 && fs.existsSync(configFilePath);
@@ -251,7 +256,7 @@ export default class Preview extends Setup {
             PreviewUtils.isTargetingBrowser(targetApp) === false &&
             configFileName.trim().length > 0
         ) {
-            const configFilePath = path.resolve(configFileName);
+            const configFilePath = path.resolve(projectDir, configFileName);
             const configFile = PreviewUtils.loadConfigFile(configFilePath);
             appConfig = configFile.getAppConfig(platform, targetApp);
             if (appConfig) {

--- a/src/cli/commands/force/lightning/lwc/previewConfigurationSchema.json
+++ b/src/cli/commands/force/lightning/lwc/previewConfigurationSchema.json
@@ -41,6 +41,10 @@
           "items": {
             "$ref": "#/definitions/launch_argument"
           }
+        },
+        "preview_server_enabled": {
+          "type": "boolean",
+          "description": "A boolean indicating whether a local development server is required for previewing a component."
         }
       },
       "required": ["id", "name"]

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -73,18 +73,20 @@ export class AndroidLauncher {
                 await AndroidSDKUtils.pollDeviceStatus(actualPort);
 
                 const address =
-                    appConfig && appConfig.preview_server_enabled === true
+                    PreviewUtils.isTargetingBrowser(targetApp) ||
+                    (appConfig && appConfig.preview_server_enabled === true)
                         ? 'http://10.0.2.2' // TODO: dynamically determine server address
                         : undefined;
 
                 const port =
-                    appConfig && appConfig.preview_server_enabled === true
+                    PreviewUtils.isTargetingBrowser(targetApp) ||
+                    (appConfig && appConfig.preview_server_enabled === true)
                         ? serverPort
                         : undefined;
 
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);
-                    const url = `${address}:${serverPort}/lwc/preview/${compPath}`;
+                    const url = `${address}:${port}/lwc/preview/${compPath}`;
                     spinner.stop(`Opening Browser with url ${url}`);
                     return AndroidSDKUtils.launchURLIntent(url, actualPort);
                 } else {

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -22,7 +22,8 @@ export class AndroidLauncher {
         projectDir: string,
         appBundlePath: string | undefined,
         targetApp: string,
-        appConfig: AndroidAppPreviewConfig | undefined
+        appConfig: AndroidAppPreviewConfig | undefined,
+        serverPort: string
     ): Promise<boolean> {
         const preferredPack = await AndroidSDKUtils.findRequiredEmulatorImages();
         const emuImage = preferredPack.platformEmulatorImage || 'default';
@@ -73,7 +74,7 @@ export class AndroidLauncher {
 
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);
-                    const url = `http://10.0.2.2:3333/lwc/preview/${compPath}`;
+                    const url = `http://10.0.2.2:${serverPort}/lwc/preview/${compPath}`;
                     spinner.stop(`Opening Browser with url ${url}`);
                     return AndroidSDKUtils.launchURLIntent(url, actualPort);
                 } else {

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -92,7 +92,13 @@ export class AndroidLauncher {
                         targetApp,
                         targetAppArguments,
                         launchActivity,
-                        actualPort
+                        actualPort,
+                        appConfig?.preview_server_enabled === true
+                            ? 'http://10.0.2.2' // TODO: dynamically determine server address
+                            : undefined,
+                        appConfig?.preview_server_enabled === true
+                            ? serverPort
+                            : undefined
                     );
                 }
             })

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -72,17 +72,12 @@ export class AndroidLauncher {
                 });
                 await AndroidSDKUtils.pollDeviceStatus(actualPort);
 
-                const address =
-                    PreviewUtils.isTargetingBrowser(targetApp) ||
-                    (appConfig && appConfig.preview_server_enabled === true)
-                        ? 'http://10.0.2.2' // TODO: dynamically determine server address
-                        : undefined;
-
-                const port =
-                    PreviewUtils.isTargetingBrowser(targetApp) ||
-                    (appConfig && appConfig.preview_server_enabled === true)
-                        ? serverPort
-                        : undefined;
+                const useServer = PreviewUtils.useLwcServerForPreviewing(
+                    targetApp,
+                    appConfig
+                );
+                const address = useServer ? 'http://10.0.2.2' : undefined; // TODO: dynamically determine server address
+                const port = useServer ? serverPort : undefined;
 
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -72,9 +72,19 @@ export class AndroidLauncher {
                 });
                 await AndroidSDKUtils.pollDeviceStatus(actualPort);
 
+                const address =
+                    appConfig && appConfig.preview_server_enabled === true
+                        ? 'http://10.0.2.2' // TODO: dynamically determine server address
+                        : undefined;
+
+                const port =
+                    appConfig && appConfig.preview_server_enabled === true
+                        ? serverPort
+                        : undefined;
+
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);
-                    const url = `http://10.0.2.2:${serverPort}/lwc/preview/${compPath}`;
+                    const url = `${address}:${serverPort}/lwc/preview/${compPath}`;
                     spinner.stop(`Opening Browser with url ${url}`);
                     return AndroidSDKUtils.launchURLIntent(url, actualPort);
                 } else {
@@ -93,12 +103,8 @@ export class AndroidLauncher {
                         targetAppArguments,
                         launchActivity,
                         actualPort,
-                        appConfig?.preview_server_enabled === true
-                            ? 'http://10.0.2.2' // TODO: dynamically determine server address
-                            : undefined,
-                        appConfig?.preview_server_enabled === true
-                            ? serverPort
-                            : undefined
+                        address,
+                        port
                     );
                 }
             })

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -457,7 +457,11 @@ export class AndroidSDKUtils {
         targetApp: string,
         targetAppArguments: LaunchArgument[],
         launchActivity: string,
-        emulatorPort: number
+        emulatorPort: number,
+        // tslint:disable-next-line: no-unnecessary-initializer
+        serverAddress: string | undefined = undefined,
+        // tslint:disable-next-line: no-unnecessary-initializer
+        serverPort: string | undefined = undefined
     ): Promise<boolean> {
         try {
             if (appBundlePath && appBundlePath.trim().length > 0) {
@@ -472,6 +476,14 @@ export class AndroidSDKUtils {
             let launchArgs =
                 `--es "${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}" "${compName}"` +
                 ` --es "${PreviewUtils.PROJECT_DIR_ARG_PREFIX}" "${projectDir}"`;
+
+            if (serverAddress) {
+                launchArgs += ` --es "${PreviewUtils.SERVER_ADDRESS_PREFIX}" "${serverAddress}"`;
+            }
+
+            if (serverPort) {
+                launchArgs += ` --es "${PreviewUtils.SERVER_PORT_PREFIX}" "${serverPort}"`;
+            }
 
             targetAppArguments.forEach((arg) => {
                 launchArgs += ` --es "${arg.name}" "${arg.value}"`;

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -464,7 +464,8 @@ export class AndroidSDKUtils {
                 AndroidSDKUtils.logger.info(
                     `Installing app ${appBundlePath.trim()} to emulator`
                 );
-                const installCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} install -r -t '${appBundlePath.trim()}'`;
+                const pathQuote = process.platform === WINDOWS_OS ? '"' : "'";
+                const installCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} install -r -t ${pathQuote}${appBundlePath.trim()}${pathQuote}`;
                 AndroidSDKUtils.executeCommand(installCommand);
             }
 

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -731,7 +731,7 @@ export class AndroidSDKUtils {
     private static isEmulatorAlreadyStarted(emulatorName: string): boolean {
         const findProcessCommand =
             process.platform === WINDOWS_OS
-                ? `tasklist /V /FI "IMAGENAME eq qemu-system-x86_64.exe" | findstr "${emulatorName}"`
+                ? `wmic process where "CommandLine Like \'%qemu-system-x86_64%\'" get CommandLine  | findstr "${emulatorName}"`
                 : `ps -ax | grep qemu-system-x86_64 | grep ${emulatorName} | grep -v grep`;
 
         // ram.img.dirty is a one byte file created when avd is started and removed when avd is stopped.

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -458,10 +458,8 @@ export class AndroidSDKUtils {
         targetAppArguments: LaunchArgument[],
         launchActivity: string,
         emulatorPort: number,
-        // tslint:disable-next-line: no-unnecessary-initializer
-        serverAddress: string | undefined = undefined,
-        // tslint:disable-next-line: no-unnecessary-initializer
-        serverPort: string | undefined = undefined
+        serverAddress: string | undefined,
+        serverPort: string | undefined
     ): Promise<boolean> {
         try {
             if (appBundlePath && appBundlePath.trim().length > 0) {

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -9,7 +9,6 @@ import * as childProcess from 'child_process';
 import { Logger } from '@salesforce/core';
 
 const execSync = childProcess.execSync;
-const spawn = childProcess.spawn;
 type StdioOptions = childProcess.StdioOptions;
 
 const LOGGER_NAME = 'force:lightning:mobile:common';
@@ -50,73 +49,29 @@ export class CommonUtils {
     }
 
     public static getLwcServerPort(): string | undefined {
-        // The LWC server runs a few processes in the background, one of which is hardcoded
-        // to run on port 9856. So we can see whether the LWC server is running by checking
-        // whether there is a process that is using port 9856. Then we can check to see what
-        // other port is that process listening to, and that would be the server port.
-
-        const isWindows = process.platform === 'win32';
-
-        const getServerPIDCommand = isWindows
-            ? 'netstat -vanpo tcp | findstr ":9856"'
-            : 'netstat -vanp tcp | grep "*.9856"';
-        let serverPID = '';
-        try {
-            const result = CommonUtils.executeCommand(getServerPIDCommand);
-            const parts = result.split(' ').filter((i) => i);
-
-            if (isWindows) {
-                // On Windows the result would be something like below:
-                //    Proto  Local Address      Foreign Address       State               PID
-                //    TCP    0.0.0.0:9856       0.0.0.0:0             LISTENING           12468
-                if (parts.length >= 5) {
-                    serverPID = parts[4].trim();
-                }
-            } else {
-                // On Mac the result would be something like below:
-                //    Proto  Recv-Q  Send-Q  Local Address  Foreign Address  (state)  rhiwat  shiwat  pid    epid  state   options
-                //    tcp46       0       0  *.9856         *.*              LISTEN   131072  131072  37515     0  0x0100  0x00000106
-                if (parts.length >= 12) {
-                    serverPID = parts[8].trim();
-                }
-            }
-        } catch (error) {
-            // if we got here then it means that server is not running
-        }
-
-        if (serverPID === '') {
-            // Did not detect server to be running so no port number to return
-            return undefined;
-        }
-
-        const getServerPort = isWindows
-            ? `netstat -vanpo tcp | findstr "${serverPID}" | findstr /v /c:":9856"`
-            : `netstat -vanp tcp | grep "${serverPID}" | grep -v "*.9856"`;
+        const getProcessCommand =
+            process.platform === 'win32'
+                ? 'wmic process where "CommandLine Like \'%force:lightning:lwc:start%\'" get CommandLine  | findstr "sfdx.js"'
+                : "ps -ax | grep 'force:lightning:lwc:start' | grep 'sfdx.js' | grep -v grep";
 
         try {
-            const result = CommonUtils.executeCommand(getServerPort);
-            const parts = result.split(' ').filter((i) => i);
+            const result = CommonUtils.executeCommand(getProcessCommand).trim();
+            // The result of the above command would be in the form of [ "........./sfdx.js" "force:lightning:lwc:start" ]
+            // when no port is specified, or in the form of [ "........./sfdx.js" "force:lightning:lwc:start" "-p" "1234" ]
+            // when a port is specified.
 
-            if (isWindows) {
-                // On Windows the result would be something like below:
-                //    Proto  Local Address      Foreign Address       State               PID
-                //    TCP    0.0.0.0:3000       0.0.0.0:0             LISTENING           12468
-                if (parts.length >= 5) {
-                    return parts[1].replace('0.0.0.0:', '').trim();
-                }
-            } else {
-                // On Mac the result would be something like below:
-                //    Proto  Recv-Q  Send-Q  Local Address  Foreign Address  (state)  rhiwat  shiwat  pid    epid  state   options
-                //    tcp46       0       0  *.3000         *.*              LISTEN   131072  131072  37515     0  0x0100  0x00000106
-                if (parts.length >= 12) {
-                    return parts[3].replace('*.', '').trim();
-                }
+            let port = '3333'; // default to 3333
+            const pIndex = result.indexOf('-p');
+            if (pIndex > 0) {
+                port = result
+                    .substr(pIndex + 2)
+                    .replace(/"/gi, '')
+                    .trim();
             }
-        } catch (error) {
-            CommonUtils.logger.error(
-                `Error executing command '${getServerPort}':`
-            );
-            CommonUtils.logger.error(`${error}`);
+            return port;
+        } catch {
+            // If we got here it's b/c the grep command fails on empty set,
+            // which means that the server is not running
         }
 
         return undefined;

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -49,5 +49,78 @@ export class CommonUtils {
         });
     }
 
+    public static getLwcServerPort(): string | undefined {
+        // The LWC server runs a few processes in the background, one of which is hardcoded
+        // to run on port 9856. So we can see whether the LWC server is running by checking
+        // whether there is a process that is using port 9856. Then we can check to see what
+        // other port is that process listening to, and that would be the server port.
+
+        const isWindows = process.platform === 'win32';
+
+        const getServerPIDCommand = isWindows
+            ? 'netstat -vanpo tcp | findstr ":9856"'
+            : 'netstat -vanp tcp | grep "*.9856"';
+        let serverPID = '';
+        try {
+            const result = CommonUtils.executeCommand(getServerPIDCommand);
+            const parts = result.split(' ').filter((i) => i);
+
+            if (isWindows) {
+                // On Windows the result would be something like below:
+                //    Proto  Local Address      Foreign Address       State               PID
+                //    TCP    0.0.0.0:9856       0.0.0.0:0             LISTENING           12468
+                if (parts.length >= 5) {
+                    serverPID = parts[4].trim();
+                }
+            } else {
+                // On Mac the result would be something like below:
+                //    Proto  Recv-Q  Send-Q  Local Address  Foreign Address  (state)  rhiwat  shiwat  pid    epid  state   options
+                //    tcp46       0       0  *.9856         *.*              LISTEN   131072  131072  37515     0  0x0100  0x00000106
+                if (parts.length >= 12) {
+                    serverPID = parts[8].trim();
+                }
+            }
+        } catch (error) {
+            // if we got here then it means that server is not running
+        }
+
+        if (serverPID === '') {
+            // Did not detect server to be running so no port number to return
+            return undefined;
+        }
+
+        const getServerPort = isWindows
+            ? `netstat -vanpo tcp | findstr "${serverPID}" | findstr /v /c:":9856"`
+            : `netstat -vanp tcp | grep "${serverPID}" | grep -v "*.9856"`;
+
+        try {
+            const result = CommonUtils.executeCommand(getServerPort);
+            const parts = result.split(' ').filter((i) => i);
+
+            if (isWindows) {
+                // On Windows the result would be something like below:
+                //    Proto  Local Address      Foreign Address       State               PID
+                //    TCP    0.0.0.0:3000       0.0.0.0:0             LISTENING           12468
+                if (parts.length >= 5) {
+                    return parts[1].replace('0.0.0.0:', '').trim();
+                }
+            } else {
+                // On Mac the result would be something like below:
+                //    Proto  Recv-Q  Send-Q  Local Address  Foreign Address  (state)  rhiwat  shiwat  pid    epid  state   options
+                //    tcp46       0       0  *.3000         *.*              LISTEN   131072  131072  37515     0  0x0100  0x00000106
+                if (parts.length >= 12) {
+                    return parts[3].replace('*.', '').trim();
+                }
+            }
+        } catch (error) {
+            CommonUtils.logger.error(
+                `Error executing command '${getServerPort}':`
+            );
+            CommonUtils.logger.error(`${error}`);
+        }
+
+        return undefined;
+    }
+
     private static logger: Logger = new Logger(LOGGER_NAME);
 }

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -14,6 +14,8 @@ type StdioOptions = childProcess.StdioOptions;
 const LOGGER_NAME = 'force:lightning:mobile:common';
 
 export class CommonUtils {
+    public static DEFAULT_LWC_SERVER_PORT = '3333';
+
     public static async initializeLogger(): Promise<void> {
         CommonUtils.logger = await Logger.child(LOGGER_NAME);
         return Promise.resolve();
@@ -60,7 +62,7 @@ export class CommonUtils {
             // when no port is specified, or in the form of [ "........./sfdx.js" "force:lightning:lwc:start" "-p" "1234" ]
             // when a port is specified.
 
-            let port = '3333'; // default to 3333
+            let port = CommonUtils.DEFAULT_LWC_SERVER_PORT;
             const pIndex = result.indexOf('-p');
             if (pIndex > 0) {
                 port = result
@@ -72,9 +74,8 @@ export class CommonUtils {
         } catch {
             // If we got here it's b/c the grep command fails on empty set,
             // which means that the server is not running
+            return undefined;
         }
-
-        return undefined;
     }
 
     private static logger: Logger = new Logger(LOGGER_NAME);

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -93,7 +93,13 @@ export class IOSLauncher {
                         projectDir,
                         appBundlePath,
                         targetApp,
-                        targetAppArguments
+                        targetAppArguments,
+                        appConfig?.preview_server_enabled === true
+                            ? 'http://localhost' // TODO: dynamically determine server address
+                            : undefined,
+                        appConfig?.preview_server_enabled === true
+                            ? serverPort
+                            : undefined
                     );
                 }
             })

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -24,7 +24,8 @@ export class IOSLauncher {
         projectDir: string,
         appBundlePath: string | undefined,
         targetApp: string,
-        appConfig: IOSAppPreviewConfig | undefined
+        appConfig: IOSAppPreviewConfig | undefined,
+        serverPort: string
     ): Promise<boolean> {
         const availableDevices: string[] = await IOSUtils.getSupportedDevices();
         const supportedRuntimes: string[] = await IOSUtils.getSupportedRuntimes();
@@ -81,7 +82,7 @@ export class IOSLauncher {
             .then(() => {
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);
-                    const url = `http://localhost:3333/lwc/preview/${compPath}`;
+                    const url = `http://localhost:${serverPort}/lwc/preview/${compPath}`;
                     return IOSUtils.launchURLInBootedSimulator(deviceUDID, url);
                 } else {
                     const targetAppArguments: LaunchArgument[] =

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -80,9 +80,19 @@ export class IOSLauncher {
                 return IOSUtils.waitUntilDeviceIsReady(deviceUDID);
             })
             .then(() => {
+                const address =
+                    appConfig && appConfig.preview_server_enabled === true
+                        ? 'http://localhost' // TODO: dynamically determine server address
+                        : undefined;
+
+                const port =
+                    appConfig && appConfig.preview_server_enabled === true
+                        ? serverPort
+                        : undefined;
+
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);
-                    const url = `http://localhost:${serverPort}/lwc/preview/${compPath}`;
+                    const url = `${address}:${serverPort}/lwc/preview/${compPath}`;
                     return IOSUtils.launchURLInBootedSimulator(deviceUDID, url);
                 } else {
                     const targetAppArguments: LaunchArgument[] =
@@ -94,12 +104,8 @@ export class IOSLauncher {
                         appBundlePath,
                         targetApp,
                         targetAppArguments,
-                        appConfig?.preview_server_enabled === true
-                            ? 'http://localhost' // TODO: dynamically determine server address
-                            : undefined,
-                        appConfig?.preview_server_enabled === true
-                            ? serverPort
-                            : undefined
+                        address,
+                        port
                     );
                 }
             })

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -80,17 +80,12 @@ export class IOSLauncher {
                 return IOSUtils.waitUntilDeviceIsReady(deviceUDID);
             })
             .then(() => {
-                const address =
-                    PreviewUtils.isTargetingBrowser(targetApp) ||
-                    (appConfig && appConfig.preview_server_enabled === true)
-                        ? 'http://localhost' // TODO: dynamically determine server address
-                        : undefined;
-
-                const port =
-                    PreviewUtils.isTargetingBrowser(targetApp) ||
-                    (appConfig && appConfig.preview_server_enabled === true)
-                        ? serverPort
-                        : undefined;
+                const useServer = PreviewUtils.useLwcServerForPreviewing(
+                    targetApp,
+                    appConfig
+                );
+                const address = useServer ? 'http://localhost' : undefined; // TODO: dynamically determine server address
+                const port = useServer ? serverPort : undefined;
 
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -81,18 +81,20 @@ export class IOSLauncher {
             })
             .then(() => {
                 const address =
-                    appConfig && appConfig.preview_server_enabled === true
+                    PreviewUtils.isTargetingBrowser(targetApp) ||
+                    (appConfig && appConfig.preview_server_enabled === true)
                         ? 'http://localhost' // TODO: dynamically determine server address
                         : undefined;
 
                 const port =
-                    appConfig && appConfig.preview_server_enabled === true
+                    PreviewUtils.isTargetingBrowser(targetApp) ||
+                    (appConfig && appConfig.preview_server_enabled === true)
                         ? serverPort
                         : undefined;
 
                 if (PreviewUtils.isTargetingBrowser(targetApp)) {
                     const compPath = PreviewUtils.prefixRouteIfNeeded(compName);
-                    const url = `${address}:${serverPort}/lwc/preview/${compPath}`;
+                    const url = `${address}:${port}/lwc/preview/${compPath}`;
                     return IOSUtils.launchURLInBootedSimulator(deviceUDID, url);
                 } else {
                     const targetAppArguments: LaunchArgument[] =

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -67,7 +67,7 @@ export class IOSUtils {
             try {
                 const devices = await IOSUtils.getSupportedSimulators();
                 for (const device of devices) {
-                    if (simulatorName.match(device.name)) {
+                    if (simulatorName === device.name) {
                         return resolve(device);
                     }
                 }

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -269,7 +269,11 @@ export class IOSUtils {
         projectDir: string,
         appBundlePath: string | undefined,
         targetApp: string,
-        targetAppArguments: LaunchArgument[]
+        targetAppArguments: LaunchArgument[],
+        // tslint:disable-next-line: no-unnecessary-initializer
+        serverAddress: string | undefined = undefined,
+        // tslint:disable-next-line: no-unnecessary-initializer
+        serverPort: string | undefined = undefined
     ): Promise<boolean> {
         if (appBundlePath && appBundlePath.trim().length > 0) {
             const installCommand = `${XCRUN_CMD} simctl install ${udid} '${appBundlePath.trim()}'`;
@@ -289,6 +293,14 @@ export class IOSUtils {
         let launchArgs =
             `${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}=${compName}` +
             ` ${PreviewUtils.PROJECT_DIR_ARG_PREFIX}=${projectDir}`;
+
+        if (serverAddress) {
+            launchArgs += ` ${PreviewUtils.SERVER_ADDRESS_PREFIX}=${serverAddress}`;
+        }
+
+        if (serverPort) {
+            launchArgs += ` ${PreviewUtils.SERVER_PORT_PREFIX}=${serverPort}`;
+        }
 
         targetAppArguments.forEach((arg) => {
             launchArgs += ` ${arg.name}=${arg.value}`;

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -270,10 +270,8 @@ export class IOSUtils {
         appBundlePath: string | undefined,
         targetApp: string,
         targetAppArguments: LaunchArgument[],
-        // tslint:disable-next-line: no-unnecessary-initializer
-        serverAddress: string | undefined = undefined,
-        // tslint:disable-next-line: no-unnecessary-initializer
-        serverPort: string | undefined = undefined
+        serverAddress: string | undefined,
+        serverPort: string | undefined
     ): Promise<boolean> {
         if (appBundlePath && appBundlePath.trim().length > 0) {
             const installCommand = `${XCRUN_CMD} simctl install ${udid} '${appBundlePath.trim()}'`;

--- a/src/common/PreviewConfigFile.ts
+++ b/src/common/PreviewConfigFile.ts
@@ -42,6 +42,8 @@ class BaseAppPreviewConfig {
     public get_app_bundle?: string;
     // tslint:disable-next-line: variable-name
     public launch_arguments?: LaunchArgument[];
+    // tslint:disable-next-line: variable-name
+    public preview_server_enabled?: boolean;
 }
 
 // tslint:disable-next-line: max-classes-per-file

--- a/src/common/PreviewUtils.ts
+++ b/src/common/PreviewUtils.ts
@@ -24,6 +24,8 @@ export class PreviewUtils {
     public static BROWSER_TARGET_APP = 'browser';
     public static COMPONENT_NAME_ARG_PREFIX = `${NAMESPACE}.componentname`;
     public static PROJECT_DIR_ARG_PREFIX = `${NAMESPACE}.projectdir`;
+    public static SERVER_PORT_PREFIX = `${NAMESPACE}.serverport`;
+    public static SERVER_ADDRESS_PREFIX = `${NAMESPACE}.serveraddress`;
 
     public static isTargetingBrowser(targetApp: string): boolean {
         return (

--- a/src/common/PreviewUtils.ts
+++ b/src/common/PreviewUtils.ts
@@ -33,6 +33,17 @@ export class PreviewUtils {
         );
     }
 
+    public static useLwcServerForPreviewing(
+        targetApp: string,
+        appConfig: IOSAppPreviewConfig | AndroidAppPreviewConfig | undefined
+    ): boolean {
+        return (
+            PreviewUtils.isTargetingBrowser(targetApp) ||
+            (appConfig !== undefined &&
+                appConfig.preview_server_enabled === true)
+        );
+    }
+
     public static prefixRouteIfNeeded(compName: string): string {
         if (compName.toLowerCase().startsWith('c/')) {
             return compName;

--- a/src/common/Requirements.ts
+++ b/src/common/Requirements.ts
@@ -210,7 +210,7 @@ export abstract class BaseSetup implements RequirementList {
         });
     }
 
-    protected addRequirements(reqs: Requirement[]) {
+    public addRequirements(reqs: Requirement[]) {
         if (reqs) {
             this.requirements = this.requirements.concat(reqs);
         }

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -460,10 +460,12 @@ describe('Android utils', () => {
             port
         );
 
+        const pathQuote = process.platform === 'win32' ? '"' : "'";
+
         expect(mockCmd).toBeCalledTimes(2);
         expect(mockCmd).nthCalledWith(
             1,
-            `${adbCommand} -s emulator-${port} install -r -t '${appBundlePath.trim()}'`
+            `${adbCommand} -s emulator-${port} install -r -t ${pathQuote}${appBundlePath.trim()}${pathQuote}`
         );
         expect(mockCmd).nthCalledWith(
             2,

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -386,7 +386,9 @@ describe('Android utils', () => {
             targetApp,
             targetAppArgs,
             targetActivity,
-            port
+            port,
+            undefined,
+            undefined
         );
 
         expect(mockCmd).toBeCalledTimes(1);
@@ -420,7 +422,9 @@ describe('Android utils', () => {
             targetApp,
             targetAppArgs,
             targetActivity,
-            port
+            port,
+            undefined,
+            undefined
         ).catch((error) => {
             expect(error).toBeTruthy();
         });
@@ -457,7 +461,9 @@ describe('Android utils', () => {
             targetApp,
             targetAppArgs,
             targetActivity,
-            port
+            port,
+            undefined,
+            undefined
         );
 
         const pathQuote = process.platform === 'win32' ? '"' : "'";

--- a/src/common/__tests__/IOSUtils.test.ts
+++ b/src/common/__tests__/IOSUtils.test.ts
@@ -223,7 +223,9 @@ describe('IOS utils tests', () => {
             projectDir,
             undefined,
             targetApp,
-            targetAppArgs
+            targetAppArgs,
+            undefined,
+            undefined
         );
 
         expect(launchCommandMock).toBeCalledTimes(2);
@@ -257,7 +259,9 @@ describe('IOS utils tests', () => {
             projectDir,
             undefined,
             targetApp,
-            targetAppArgs
+            targetAppArgs,
+            undefined,
+            undefined
         ).catch((error) => {
             expect(error).toBeTruthy();
         });
@@ -288,7 +292,9 @@ describe('IOS utils tests', () => {
             projectDir,
             appBundlePath,
             targetApp,
-            targetAppArgs
+            targetAppArgs,
+            undefined,
+            undefined
         );
 
         expect(launchCommandMock).toBeCalledTimes(3);


### PR DESCRIPTION
Update the Preview command to:
1. Check whether the local dev server is running, as a pre-requisite
2. Determine the server port dynamically at runtime instead of always hard-coding to use port 3333