### PR TITLE
Remove dash from device name

### DIFF
--- a/src/common/AndroidTypes.ts
+++ b/src/common/AndroidTypes.ts
@@ -224,7 +224,7 @@ export class AndroidVirtualDevice {
         api: string
     ) {
         this.name = name;
-        this.displayName = name.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL
+        this.displayName = name.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL, tv_emulator --> tv emulator
         this.deviceName = deviceName.replace(/\([^\(]*\)/, '').trim(); // eg. Nexus 5X (Google) --> Nexus 5X
         this.path = path.trim();
         this.target = target.replace(/\([^\(]*\)/, '').trim(); // eg. Google APIs (Google Inc.) --> Google APIs

--- a/src/common/AndroidTypes.ts
+++ b/src/common/AndroidTypes.ts
@@ -224,7 +224,7 @@ export class AndroidVirtualDevice {
         api: string
     ) {
         this.name = name;
-        this.displayName = name.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL, tv_emulator --> tv emulator
+        this.displayName = name.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL, tv-emulator --> tv emulator
         this.deviceName = deviceName.replace(/\([^\(]*\)/, '').trim(); // eg. Nexus 5X (Google) --> Nexus 5X
         this.path = path.trim();
         this.target = target.replace(/\([^\(]*\)/, '').trim(); // eg. Google APIs (Google Inc.) --> Google APIs

--- a/src/common/AndroidTypes.ts
+++ b/src/common/AndroidTypes.ts
@@ -224,7 +224,7 @@ export class AndroidVirtualDevice {
         api: string
     ) {
         this.name = name;
-        this.displayName = name.replace(/_/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL
+        this.displayName = name.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL
         this.deviceName = deviceName.replace(/\([^\(]*\)/, '').trim(); // eg. Nexus 5X (Google) --> Nexus 5X
         this.path = path.trim();
         this.target = target.replace(/\([^\(]*\)/, '').trim(); // eg. Google APIs (Google Inc.) --> Google APIs


### PR DESCRIPTION
Android emulators whose type is phone will have `' '`(space) in their names internally be represented using `_` instead. But for emulators that are non-phone types, like tv, have `' '` represented by `-`. This fix will replace `-` with `' '` for non-phone type emulators and display emulator names that are equivalent to names displayed in AVD Manager.

Note: Non-phone emulator created using older Android Studio uses `-` for `' '`. Non-phone emulator created using current Android Studio(4.1.1) uses `_` for `' '`.