### PR TITLE
refactor sync+async versions of exec

### DIFF
--- a/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
+++ b/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
@@ -102,7 +102,9 @@ describe('Preview Tests', () => {
         const cmdMock = jest.fn((): string => {
             throw new Error('test error');
         });
-        jest.spyOn(CommonUtils, 'executeCommand').mockImplementation(cmdMock);
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+            cmdMock
+        );
         preview.isLwcServerRunning().catch((error) => {
             expect(typeof error === 'string').toBeTruthy();
         });
@@ -115,7 +117,9 @@ describe('Preview Tests', () => {
         const cmdMock = jest.fn((): string => {
             return 'path/to/bin/node /path/to/bin/sfdx.js force:lightning:lwc:start';
         });
-        jest.spyOn(CommonUtils, 'executeCommand').mockImplementation(cmdMock);
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+            cmdMock
+        );
         const port = (await preview.isLwcServerRunning()).trim();
         expect(port).toBe('3333');
     });
@@ -128,7 +132,9 @@ describe('Preview Tests', () => {
         const cmdMock = jest.fn((): string => {
             return `path/to/bin/node /path/to/bin/sfdx.js force:lightning:lwc:start -p ${specifiedPort}`;
         });
-        jest.spyOn(CommonUtils, 'executeCommand').mockImplementation(cmdMock);
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+            cmdMock
+        );
         const port = (await preview.isLwcServerRunning()).trim();
         expect(port).toBe(specifiedPort);
     });

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -56,13 +56,6 @@ export class AndroidSDKUtils {
         return !AndroidSDKUtils.packageCache.isEmpty();
     }
 
-    public static executeCommand(
-        command: string,
-        stdioOptions: StdioOptions = ['ignore', 'pipe', 'ignore']
-    ): string {
-        return CommonUtils.executeCommand(command, stdioOptions);
-    }
-
     public static isJavaHomeSet(): boolean {
         return process.env.JAVA_HOME
             ? process.env.JAVA_HOME.trim().length > 0
@@ -125,7 +118,7 @@ export class AndroidSDKUtils {
                 return;
             }
             try {
-                AndroidSDKUtils.executeCommand(
+                CommonUtils.executeCommandSync(
                     `${AndroidSDKUtils.getSdkManagerCommand()} --version`,
                     stdioOptions
                 );
@@ -145,7 +138,7 @@ export class AndroidSDKUtils {
                 return reject(new Error('Android SDK root is not set.'));
             }
             try {
-                AndroidSDKUtils.executeCommand(
+                CommonUtils.executeCommandSync(
                     `${AndroidSDKUtils.getAdbShellCommand()} --version`
                 );
                 resolve(AndroidSDKUtils.getAndroidPlatformTools());
@@ -162,7 +155,7 @@ export class AndroidSDKUtils {
 
         if (!AndroidSDKUtils.isCached()) {
             try {
-                const stdout = AndroidSDKUtils.executeCommand(
+                const stdout = CommonUtils.executeCommandSync(
                     `${AndroidSDKUtils.getSdkManagerCommand()} --list`
                 );
                 if (stdout) {
@@ -183,7 +176,7 @@ export class AndroidSDKUtils {
         return new Promise((resolve, reject) => {
             let devices: AndroidVirtualDevice[] = [];
             try {
-                const result = AndroidSDKUtils.executeCommand(
+                const result = CommonUtils.executeCommandSync(
                     AndroidSDKUtils.getAvdManagerCommand() + ' list avd'
                 );
                 if (result) {
@@ -284,7 +277,7 @@ export class AndroidSDKUtils {
         return new Promise<number>((resolve, reject) => {
             let adbPort = 0;
             try {
-                const stdout = AndroidSDKUtils.executeCommand(command);
+                const stdout = CommonUtils.executeCommandSync(command);
                 let listOfDevices: number[] = stdout
                     .toString()
                     .split(os.EOL)
@@ -437,7 +430,7 @@ export class AndroidSDKUtils {
         return new Promise<boolean>((resolve, reject) => {
             const timeoutFunc = (commandStr: string, noOfRetries: number) => {
                 try {
-                    const stdout = AndroidSDKUtils.executeCommand(commandStr);
+                    const stdout = CommonUtils.executeCommandSync(commandStr);
                     if (stdout && stdout.trim() === '1') {
                         resolve(true);
                     } else {
@@ -475,7 +468,7 @@ export class AndroidSDKUtils {
         const openUrlCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} shell am start -a android.intent.action.VIEW -d ${url}`;
         return new Promise((resolve, reject) => {
             try {
-                AndroidSDKUtils.executeCommand(openUrlCommand);
+                CommonUtils.executeCommandSync(openUrlCommand);
                 resolve(true);
             } catch (error) {
                 reject(error);
@@ -501,7 +494,7 @@ export class AndroidSDKUtils {
                 );
                 const pathQuote = process.platform === WINDOWS_OS ? '"' : "'";
                 const installCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} install -r -t ${pathQuote}${appBundlePath.trim()}${pathQuote}`;
-                AndroidSDKUtils.executeCommand(installCommand);
+                CommonUtils.executeCommandSync(installCommand);
             }
 
             let launchArgs =
@@ -530,7 +523,7 @@ export class AndroidSDKUtils {
             AndroidSDKUtils.logger.info(
                 `Relaunching app ${targetApp} in emulator`
             );
-            AndroidSDKUtils.executeCommand(launchCommand);
+            CommonUtils.executeCommandSync(launchCommand);
 
             return Promise.resolve(true);
         } catch (error) {
@@ -824,7 +817,9 @@ export class AndroidSDKUtils {
         // then ensure that the process is also running for the selected emulator
         let foundProcess = false;
         try {
-            const findResult = CommonUtils.executeCommand(findProcessCommand);
+            const findResult = CommonUtils.executeCommandSync(
+                findProcessCommand
+            );
             foundProcess = findResult != null && findResult.trim().length > 0;
         } catch (error) {
             AndroidSDKUtils.logger.debug(
@@ -856,7 +851,7 @@ export class AndroidSDKUtils {
         const emulatorDisplayName = emulatorName.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL, tv-emulator --> tv emulator
 
         try {
-            const stdout = AndroidSDKUtils.executeCommand(
+            const stdout = CommonUtils.executeCommandSync(
                 AndroidSDKUtils.getEmulatorCommand() + ' ' + '-list-avds'
             );
             const listOfAVDs = stdout.toString().split(os.EOL);

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -5,10 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import * as childProcess from 'child_process';
-
 import { Logger } from '@salesforce/core';
 
-const execSync = childProcess.execSync;
 type StdioOptions = childProcess.StdioOptions;
 
 const LOGGER_NAME = 'force:lightning:mobile:common';
@@ -21,15 +19,17 @@ export class CommonUtils {
         return Promise.resolve();
     }
 
-    public static executeCommand(
+    public static executeCommandSync(
         command: string,
         stdioOptions: StdioOptions = ['ignore', 'pipe', 'ignore']
     ): string {
         CommonUtils.logger.debug(`Executing command: '${command}'.`);
         try {
-            return execSync(command, {
-                stdio: stdioOptions
-            }).toString();
+            return childProcess
+                .execSync(command, {
+                    stdio: stdioOptions
+                })
+                .toString();
         } catch (error) {
             CommonUtils.logger.error(`Error executing command '${command}':`);
             CommonUtils.logger.error(`${error}`);
@@ -37,11 +37,32 @@ export class CommonUtils {
         }
     }
 
+    public static async executeCommandAsync(
+        command: string
+    ): Promise<{ stdout: string; stderr: string }> {
+        return new Promise<{ stdout: string; stderr: string }>(
+            (resolve, reject) => {
+                CommonUtils.logger.debug(`Executing command: '${command}'.`);
+                childProcess.exec(command, (error, stdout, stderr) => {
+                    if (error) {
+                        CommonUtils.logger.error(
+                            `Error executing command '${command}':`
+                        );
+                        CommonUtils.logger.error(`${error}`);
+                        reject(error);
+                    } else {
+                        resolve({ stdout, stderr });
+                    }
+                });
+            }
+        );
+    }
+
     public static async isLwcServerPluginInstalled(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             const command = 'sfdx force:lightning:lwc:start --help';
             try {
-                CommonUtils.executeCommand(command);
+                CommonUtils.executeCommandSync(command);
                 resolve();
             } catch {
                 // Error: command force:lightning:lwc:start not found
@@ -57,7 +78,9 @@ export class CommonUtils {
                 : "ps -ax | grep 'force:lightning:lwc:start' | grep 'sfdx.js' | grep -v grep";
 
         try {
-            const result = CommonUtils.executeCommand(getProcessCommand).trim();
+            const result = CommonUtils.executeCommandSync(
+                getProcessCommand
+            ).trim();
             // The result of the above command would be in the form of [ "........./sfdx.js" "force:lightning:lwc:start" ]
             // when no port is specified, or in the form of [ "........./sfdx.js" "force:lightning:lwc:start" "-p" "1234" ]
             // when a port is specified.

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import * as childProcess from 'child_process';
 import { Logger } from '@salesforce/core';
+import * as childProcess from 'child_process';
 
 type StdioOptions = childProcess.StdioOptions;
 

--- a/src/common/IOSEnvironmentSetup.ts
+++ b/src/common/IOSEnvironmentSetup.ts
@@ -4,22 +4,14 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, Messages } from '@salesforce/core';
-import childProcess from 'child_process';
+import { Logger } from '@salesforce/core';
 import util from 'util';
 import iOSConfig from '../config/iosconfig.json';
+import { CommonUtils } from './CommonUtils';
 import { IOSUtils } from './IOSUtils';
 import { BaseSetup } from './Requirements';
 
-const exec = util.promisify(childProcess.exec);
-
 export class IOSEnvironmentSetup extends BaseSetup {
-    public static executeCommand(
-        command: string
-    ): Promise<{ stdout: string; stderr: string }> {
-        return IOSUtils.executeCommand(command);
-    }
-
     constructor(logger: Logger) {
         super(logger);
         const messages = this.setupMessages;
@@ -65,7 +57,7 @@ export class IOSEnvironmentSetup extends BaseSetup {
         const unameCommand: string = '/usr/bin/uname';
         try {
             this.logger.info('Executing a check for supported environment');
-            const { stdout } = await IOSEnvironmentSetup.executeCommand(
+            const { stdout } = await CommonUtils.executeCommandAsync(
                 unameCommand
             );
             const unameOutput = stdout.trim();
@@ -94,7 +86,7 @@ export class IOSEnvironmentSetup extends BaseSetup {
         const xcodeBuildCommand: string = 'xcodebuild -version';
         try {
             this.logger.info('Executing a check for Xcode environment');
-            const { stdout, stderr } = await IOSEnvironmentSetup.executeCommand(
+            const { stdout, stderr } = await CommonUtils.executeCommandAsync(
                 xcodeBuildCommand
             );
             if (stdout) {

--- a/src/common/Requirements.ts
+++ b/src/common/Requirements.ts
@@ -226,7 +226,7 @@ export abstract class BaseSetup implements RequirementList {
                     this.logger.info(
                         `Installing sfdx server plugin.... ${command}`
                     );
-                    CommonUtils.executeCommand(command, [
+                    CommonUtils.executeCommandSync(command, [
                         'inherit',
                         'pipe',
                         'inherit'

--- a/src/common/__tests__/AndroidEnvironmentSetup.test.ts
+++ b/src/common/__tests__/AndroidEnvironmentSetup.test.ts
@@ -11,8 +11,8 @@ process.env.ANDROID_HOME = MOCK_ANDROID_HOME;
 
 import { Logger, Messages } from '@salesforce/core';
 import { AndroidEnvironmentSetup } from '../AndroidEnvironmentSetup';
-import { CommonUtils } from '../CommonUtils';
 import { AndroidSDKRootSource, AndroidSDKUtils } from '../AndroidUtils';
+import { CommonUtils } from '../CommonUtils';
 import { AndroidMockData } from './AndroidMockData';
 
 const myCommandBlockMock = jest.fn((): string => {

--- a/src/common/__tests__/AndroidEnvironmentSetup.test.ts
+++ b/src/common/__tests__/AndroidEnvironmentSetup.test.ts
@@ -11,6 +11,7 @@ process.env.ANDROID_HOME = MOCK_ANDROID_HOME;
 
 import { Logger, Messages } from '@salesforce/core';
 import { AndroidEnvironmentSetup } from '../AndroidEnvironmentSetup';
+import { CommonUtils } from '../CommonUtils';
 import { AndroidSDKRootSource, AndroidSDKUtils } from '../AndroidUtils';
 import { AndroidMockData } from './AndroidMockData';
 
@@ -63,7 +64,7 @@ describe('Android enviroment setup tests', () => {
     });
 
     test('Should resolve when Android sdk tools are present', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             () => MOCK_ANDROID_HOME
         );
         const aPromise = andrEnvironment
@@ -73,7 +74,7 @@ describe('Android enviroment setup tests', () => {
     });
 
     test('Should reject when Android sdk tools are missing', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(() => {
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(() => {
             throw new Error('None');
         });
         const aPromise = andrEnvironment
@@ -83,7 +84,7 @@ describe('Android enviroment setup tests', () => {
     });
 
     test('Should resolve when Android sdk platform tools are present', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             () => MOCK_ANDROID_HOME
         );
         const aPromise = andrEnvironment
@@ -93,7 +94,7 @@ describe('Android enviroment setup tests', () => {
     });
 
     test('Should reject when Android sdk platform tools are missing', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(() => {
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(() => {
             throw new Error('None');
         });
         const aPromise = andrEnvironment

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -7,6 +7,7 @@
 import fs from 'fs';
 import path from 'path';
 import { AndroidSDKRootSource, AndroidSDKUtils } from '../AndroidUtils';
+import { CommonUtils } from '../CommonUtils';
 import { PreviewUtils } from '../PreviewUtils';
 import { AndroidMockData } from './AndroidMockData';
 
@@ -80,7 +81,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to verify Android SDK prerequisites are met', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myGenericVersionsCommandBlockMock
         );
         await AndroidSDKUtils.androidSDKPrerequisitesCheck();
@@ -94,7 +95,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to look for android sdk tools (sdkmanager)', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myGenericVersionsCommandBlockMock
         );
         await AndroidSDKUtils.fetchAndroidCmdLineToolsLocation();
@@ -108,7 +109,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to look for android sdk tools (sdkmanager)', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myGenericVersionsCommandBlockMockThrows
         );
         AndroidSDKUtils.fetchAndroidCmdLineToolsLocation().catch((error) => {
@@ -117,7 +118,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to look for android sdk platform tools', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myGenericVersionsCommandBlockMock
         );
         await AndroidSDKUtils.fetchAndroidSDKPlatformToolsLocation();
@@ -127,7 +128,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to look for android sdk platform tools', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myGenericVersionsCommandBlockMockThrows
         );
         AndroidSDKUtils.fetchAndroidSDKPlatformToolsLocation().catch(
@@ -138,7 +139,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to invoke the sdkmanager for installed packages', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         await AndroidSDKUtils.fetchInstalledPackages();
@@ -146,7 +147,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to invoke the sdkmanager and get installed packages', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         const packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -157,7 +158,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to invoke the sdkmanager and retrieve an empty list for a bad sdkmanager list', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             badBlockMock
         );
         const packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -169,7 +170,7 @@ describe('Android utils', () => {
     });
 
     test('Should establish cache on first call', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         const packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -177,7 +178,7 @@ describe('Android utils', () => {
     });
 
     test('Should utilize cache for subsequent calls', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         let packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -187,7 +188,7 @@ describe('Android utils', () => {
     });
 
     test('Should rebuild cache after clear in subsequent calls', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         let packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -198,7 +199,7 @@ describe('Android utils', () => {
     });
 
     test('Should rebuild cache after clear in subsequent calls', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         let packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -209,7 +210,7 @@ describe('Android utils', () => {
     });
 
     test('Should Find a preferred Android package', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         const apiPackage = await AndroidSDKUtils.findRequiredAndroidAPIPackage();
@@ -219,7 +220,7 @@ describe('Android utils', () => {
     });
 
     test('Should not find a preferred Android package', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             badBlockMock
         );
         AndroidSDKUtils.findRequiredAndroidAPIPackage().catch((error) => {
@@ -228,7 +229,7 @@ describe('Android utils', () => {
     });
 
     test('Should Find a preferred Android emulator package', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             myCommandBlockMock
         );
         const apiPackage = await AndroidSDKUtils.findRequiredEmulatorImages();
@@ -238,7 +239,7 @@ describe('Android utils', () => {
     });
 
     test('Should not find a preferred Android build tools package', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             badBlockMock
         );
         AndroidSDKUtils.findRequiredEmulatorImages().catch((error) => {
@@ -337,7 +338,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to launch url and resolve.', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             launchCommandMock
         );
         const url = 'mock.url';
@@ -348,7 +349,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to launch url and reject if error is encountered.', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             launchCommandThrowsMock
         );
         const url = 'mock.url';
@@ -377,7 +378,7 @@ describe('Android utils', () => {
             return `${targetApp}/.MainActivity`;
         });
 
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             mockCmd
         );
 
@@ -405,7 +406,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to launch native app and reject if error is encountered.', async () => {
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             launchCommandThrowsMock
         );
         const compName = 'mock.compName';
@@ -452,7 +453,7 @@ describe('Android utils', () => {
             return `${targetApp}/.MainActivity`;
         });
 
-        jest.spyOn(AndroidSDKUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
             mockCmd
         );
 

--- a/src/common/__tests__/IOSEnvironmentSetup.test.ts
+++ b/src/common/__tests__/IOSEnvironmentSetup.test.ts
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 import { Logger, Messages } from '@salesforce/core';
+import { CommonUtils } from '../CommonUtils';
 
 const myUnameMock = jest.fn(
     (): Promise<{ stdout: string; stderr: string }> => {
@@ -60,7 +61,7 @@ describe('IOS Environment Setup tests', () => {
     });
 
     it('Should attempt to validate supported OS environment', async () => {
-        jest.spyOn(IOSEnvironmentSetup, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myUnameMock
         );
         const setup = new IOSEnvironmentSetup(logger);
@@ -69,7 +70,7 @@ describe('IOS Environment Setup tests', () => {
     });
 
     it('Should throw an error for an unsupported OS environment', async () => {
-        jest.spyOn(IOSEnvironmentSetup, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             badBadMock
         );
         const setup = new IOSEnvironmentSetup(logger);
@@ -80,7 +81,7 @@ describe('IOS Environment Setup tests', () => {
 
     it('Checks to see that the logger is set', async () => {
         const logInfo = jest.spyOn(logger, 'info');
-        jest.spyOn(IOSEnvironmentSetup, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myUnameMock
         );
         const setup = new IOSEnvironmentSetup(logger);
@@ -89,7 +90,7 @@ describe('IOS Environment Setup tests', () => {
     });
 
     it('Should attempt to validate supported Xcode environment', async () => {
-        jest.spyOn(IOSEnvironmentSetup, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myXcodeSelectMock
         );
         const setup = new IOSEnvironmentSetup(logger);
@@ -98,7 +99,7 @@ describe('IOS Environment Setup tests', () => {
     });
 
     it('Should throw an error for unsupported Xcode Env', async () => {
-        jest.spyOn(IOSEnvironmentSetup, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             badBadMock
         );
         const setup = new IOSEnvironmentSetup(logger);

--- a/src/common/__tests__/IOSUtils.test.ts
+++ b/src/common/__tests__/IOSUtils.test.ts
@@ -7,6 +7,7 @@
 import { ActionBase } from 'cli-ux';
 import 'jest-chain';
 import 'jest-extended';
+import { CommonUtils } from '../CommonUtils';
 import { IOSUtils } from '../IOSUtils';
 import { PreviewUtils } from '../PreviewUtils';
 import { IOSMockData } from './IOSMockData';
@@ -88,7 +89,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to invoke the xcrun for fetching sim runtimes', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandRouterBlock
         );
         await IOSUtils.getSimulatorRuntimes();
@@ -96,7 +97,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to invoke the xcrun for booting a device', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
         const udid = 'MOCKUDID';
@@ -107,7 +108,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to invoke the xcrun but fail booting a device', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandThrowsMock
         );
         const udid = 'MOCKUDID';
@@ -117,7 +118,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to create a new device', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
         const simName = 'MOCKSIM';
@@ -130,7 +131,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to invoke xcrun to boot device but resolve if device is already Booted', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandThrowsAlreadryBootedMock
         );
         const udid = 'MOCKUDID';
@@ -140,7 +141,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should wait for the device to boot', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
         const udid = 'MOCKUDID';
@@ -150,7 +151,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should wait for the device to boot and fail if error is encountered', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandThrowsMock
         );
         const udid = 'MOCKUDID';
@@ -160,7 +161,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should launch the simulator app', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
         await IOSUtils.launchSimulatorApp();
@@ -168,7 +169,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should reject if launch of simulator app fails', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandThrowsMock
         );
         return IOSUtils.launchSimulatorApp().catch((error) => {
@@ -177,7 +178,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to launch url in a booted simulator and resolve.', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
         const url = 'mock.url';
@@ -189,7 +190,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to launch url in a booted simulator and reject if error is encountered.', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandThrowsMock
         );
         const url = 'mock.url';
@@ -200,7 +201,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to launch native app in a booted simulator and resolve.', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
 
@@ -242,7 +243,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to launch native app in a booted simulator and reject if error is encountered.', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandThrowsMock
         );
         const udid = 'MOCK-UDID';
@@ -268,7 +269,7 @@ describe('IOS utils tests', () => {
     });
 
     test('SShould attempt to install native app then launch it.', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
 
@@ -316,7 +317,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to invoke the xcrun for fetching sim runtimes and return an array of values', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandRouterBlock
         );
         return IOSUtils.getSimulatorRuntimes().then((returnedValues) => {
@@ -329,7 +330,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to invoke the xcrun for fetching sim runtimes and return white listed values', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandRouterBlock
         );
         return IOSUtils.getSupportedRuntimes().then((returnedValues) => {
@@ -340,7 +341,7 @@ describe('IOS utils tests', () => {
     });
 
     test('Should attempt to invoke the xcrun for fetching sim runtimes and return white listed values', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandRouterBlock
         );
         return IOSUtils.getSupportedDevices().then((returnedValues) => {
@@ -351,7 +352,9 @@ describe('IOS utils tests', () => {
     });
 
     test('Should handle Bad JSON', async () => {
-        jest.spyOn(IOSUtils, 'executeCommand').mockImplementation(badBlockMock);
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
+            badBlockMock
+        );
         return IOSUtils.getSimulatorRuntimes().catch((error) => {
             expect(error).toBeTruthy();
         });


### PR DESCRIPTION
This PR refactors the sync & async versions of executeCommand and puts them into the common utility class so that they can be shared more easily.