### PR TITLE
clean up async methods and call chainings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
                 "-n",
                 "c/helloWorld",
                 "-t",
-                "emu2"
+                "sfdxdebug"
             ]
         },
         {
@@ -85,7 +85,7 @@
                 "-p",
                 "iOS",
                 "-n",
-                "MyNewVirtualDevice",
+                "sfdxdebug",
                 "-d",
                 "iPhone-8"
             ]
@@ -100,7 +100,7 @@
                 "-p",
                 "android",
                 "-n",
-                "MyNewVirtualDevice",
+                "sfdxdebug",
                 "-d",
                 "pixel_xl"
             ]

--- a/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
@@ -57,7 +57,7 @@ describe('List Tests', () => {
             return Promise.resolve(0);
         });
         const createNewVirtualDeviceMock = jest.fn(() => {
-            return Promise.resolve(true);
+            return Promise.resolve();
         });
         jest.spyOn(
             AndroidSDKUtils,

--- a/src/cli/commands/force/lightning/local/device/create.ts
+++ b/src/cli/commands/force/lightning/local/device/create.ts
@@ -150,27 +150,30 @@ export class Create extends Setup {
     }
 
     private async executeAndroidDeviceCreate(): Promise<any> {
-        const preferredPack = await AndroidSDKUtils.findRequiredEmulatorImages();
-        const emuImage = preferredPack.platformEmulatorImage || 'default';
-        const androidApi = preferredPack.platformAPI;
-        const abi = preferredPack.abi;
-
-        return AndroidSDKUtils.createNewVirtualDevice(
-            this.deviceName,
-            emuImage,
-            androidApi,
-            this.deviceType,
-            abi
+        return AndroidSDKUtils.findRequiredEmulatorImages().then(
+            (preferredPack) => {
+                const emuImage =
+                    preferredPack.platformEmulatorImage || 'default';
+                const androidApi = preferredPack.platformAPI;
+                const abi = preferredPack.abi;
+                return AndroidSDKUtils.createNewVirtualDevice(
+                    this.deviceName,
+                    emuImage,
+                    androidApi,
+                    this.deviceType,
+                    abi
+                );
+            }
         );
     }
 
     private async executeIOSDeviceCreate(): Promise<any> {
-        const supportedRuntimes: string[] = await IOSUtils.getSupportedRuntimes();
-
-        return IOSUtils.createNewDevice(
-            this.deviceName,
-            this.deviceType,
-            supportedRuntimes[0]
+        return IOSUtils.getSupportedRuntimes().then((supportedRuntimes) =>
+            IOSUtils.createNewDevice(
+                this.deviceName,
+                this.deviceType,
+                supportedRuntimes[0]
+            )
         );
     }
 }

--- a/src/cli/commands/force/lightning/local/device/create.ts
+++ b/src/cli/commands/force/lightning/local/device/create.ts
@@ -149,7 +149,7 @@ export class Create extends Setup {
             : this.executeIOSDeviceCreate();
     }
 
-    private async executeAndroidDeviceCreate(): Promise<any> {
+    private async executeAndroidDeviceCreate(): Promise<void> {
         return AndroidSDKUtils.findRequiredEmulatorImages().then(
             (preferredPack) => {
                 const emuImage =
@@ -167,7 +167,7 @@ export class Create extends Setup {
         );
     }
 
-    private async executeIOSDeviceCreate(): Promise<any> {
+    private async executeIOSDeviceCreate(): Promise<string> {
         return IOSUtils.getSupportedRuntimes().then((supportedRuntimes) =>
             IOSUtils.createNewDevice(
                 this.deviceName,

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -62,13 +62,9 @@ export default class List extends SfdxCommand {
             );
         }
 
-        return new Promise<any>((resolve, reject) => {
-            const deviceList = CommandLineUtils.platformFlagIsIOS(platform)
-                ? this.iOSDeviceList()
-                : this.androidDeviceList();
-
-            resolve(deviceList);
-        });
+        return CommandLineUtils.platformFlagIsIOS(platform)
+            ? this.iOSDeviceList()
+            : this.androidDeviceList();
     }
 
     public async iOSDeviceList(): Promise<IOSSimulatorDevice[]> {
@@ -76,7 +72,7 @@ export default class List extends SfdxCommand {
         const result = await IOSUtils.getSupportedSimulators();
         performance.mark(this.perfMarker.endMarkName);
         this.showDeviceList(result);
-        return result;
+        return Promise.resolve(result);
     }
 
     public async androidDeviceList(): Promise<AndroidVirtualDevice[]> {
@@ -84,7 +80,7 @@ export default class List extends SfdxCommand {
         const result = await AndroidSDKUtils.fetchEmulators();
         performance.mark(this.perfMarker.endMarkName);
         this.showDeviceList(result);
-        return result;
+        return Promise.resolve(result);
     }
 
     protected async init(): Promise<void> {

--- a/src/cli/commands/force/lightning/local/setup.ts
+++ b/src/cli/commands/force/lightning/local/setup.ts
@@ -56,24 +56,29 @@ export default class Setup extends SfdxCommand {
             );
         }
         this.logger.info(`Setup Command called for ${this.flags.platform}`);
-        const setup = this.setup();
-        const result = await this.executeSetup(setup);
-        if (!result.hasMetAllRequirements) {
-            return Promise.reject(
-                new SfdxError(
-                    util.format(
-                        messages.getMessage('error:setupFailed'),
-                        this.flags.platform
-                    ),
-                    'lwc-dev-mobile',
-                    [messages.getMessage('error:setupFailed:recommendation')]
-                )
-            );
-        }
-        return Promise.resolve(result);
+        return this.executeSetup(this.setup()).then((result) => {
+            if (!result.hasMetAllRequirements) {
+                return Promise.reject(
+                    new SfdxError(
+                        util.format(
+                            messages.getMessage('error:setupFailed'),
+                            this.flags.platform
+                        ),
+                        'lwc-dev-mobile',
+                        [
+                            messages.getMessage(
+                                'error:setupFailed:recommendation'
+                            )
+                        ]
+                    )
+                );
+            } else {
+                return Promise.resolve(result);
+            }
+        });
     }
 
-    public executeSetup(setup: BaseSetup): Promise<SetupTestResult> {
+    public async executeSetup(setup: BaseSetup): Promise<SetupTestResult> {
         return setup.executeSetup();
     }
 

--- a/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
+++ b/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
@@ -118,11 +118,16 @@ describe('Preview Tests', () => {
         setupAndroidFlags();
         const logger = new Logger('test-preview');
         setupLogger(logger);
-        const cmdMock = jest.fn((): string => {
-            return 'path/to/bin/node /path/to/bin/sfdx.js force:lightning:lwc:start';
-        });
+        const cmdMock = jest.fn(
+            (): Promise<{ stdout: string; stderr: string }> =>
+                Promise.resolve({
+                    stderr: '',
+                    stdout:
+                        'path/to/bin/node /path/to/bin/sfdx.js force:lightning:lwc:start'
+                })
+        );
 
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             cmdMock
         );
         const requirement = new LwcServerIsRunningRequirement(logger);
@@ -136,11 +141,15 @@ describe('Preview Tests', () => {
         const logger = new Logger('test-preview');
         setupLogger(logger);
         const specifiedPort = '3456';
-        const cmdMock = jest.fn((): string => {
-            return `path/to/bin/node /path/to/bin/sfdx.js force:lightning:lwc:start -p ${specifiedPort}`;
-        });
+        const cmdMock = jest.fn(
+            (): Promise<{ stdout: string; stderr: string }> =>
+                Promise.resolve({
+                    stderr: '',
+                    stdout: `path/to/bin/node /path/to/bin/sfdx.js force:lightning:lwc:start -p ${specifiedPort}`
+                })
+        );
 
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             cmdMock
         );
         const requirement = new LwcServerIsRunningRequirement(logger);

--- a/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
+++ b/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
@@ -10,11 +10,7 @@ import { CommonUtils } from '../../../../../../common/CommonUtils';
 import Setup from '../../local/setup';
 import { LwcServerIsRunningRequirement, Preview } from '../preview';
 
-const myPreviewCommandBlockMock = jest.fn(
-    (): Promise<boolean> => {
-        return Promise.resolve(true);
-    }
-);
+const myPreviewCommandBlockMock = jest.fn(() => Promise.resolve());
 
 const passedSetupMock = jest.fn(() => {
     return Promise.resolve({ hasMetAllRequirements: true, tests: [] });
@@ -52,9 +48,7 @@ describe('Preview Tests', () => {
         setupAndroidFlags();
         const logger = new Logger('test-preview');
         setupLogger(logger);
-        const targetAndroidCallMock = jest.fn(() => {
-            return Promise.resolve(true);
-        });
+        const targetAndroidCallMock = jest.fn(() => Promise.resolve());
         preview.launchPreview = targetAndroidCallMock;
         await preview.run();
         expect(targetAndroidCallMock).toHaveBeenCalled();
@@ -64,9 +58,7 @@ describe('Preview Tests', () => {
         setupIOSFlags();
         const logger = new Logger('test-preview');
         setupLogger(logger);
-        const targetIOSCallMock = jest.fn(() => {
-            return Promise.resolve(true);
-        });
+        const targetIOSCallMock = jest.fn(() => Promise.resolve());
         preview.launchPreview = targetIOSCallMock;
         await preview.run();
         expect(targetIOSCallMock).toHaveBeenCalled();

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -258,14 +258,14 @@ export class Preview extends Setup {
                 this.appConfig
             )
         ) {
-            const port = CommonUtils.getLwcServerPort();
+            const port = await CommonUtils.getLwcServerPort();
             this.serverPort = port ? port : CommonUtils.DEFAULT_LWC_SERVER_PORT;
         }
 
         return Promise.resolve();
     }
 
-    public launchPreview(): Promise<boolean> {
+    public async launchPreview(): Promise<boolean> {
         // At this point all of the inputs/parameters have been verified and parsed so we can just use them.
 
         let appBundlePath: string | undefined;
@@ -334,7 +334,7 @@ export class Preview extends Setup {
         return this.exit(0);
     }
 
-    private launchIOS(
+    private async launchIOS(
         deviceName: string,
         componentName: string,
         projectDir: string,
@@ -355,7 +355,7 @@ export class Preview extends Setup {
         );
     }
 
-    private launchAndroid(
+    private async launchAndroid(
         deviceName: string,
         componentName: string,
         projectDir: string,
@@ -393,11 +393,14 @@ export class LwcServerIsRunningRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        const port = CommonUtils.getLwcServerPort();
-        if (!port) {
-            return Promise.reject(this.unfulfilledMessage);
-        } else {
-            return Promise.resolve(util.format(this.fulfilledMessage, port));
-        }
+        return CommonUtils.getLwcServerPort().then((port) => {
+            if (!port) {
+                return Promise.reject(this.unfulfilledMessage);
+            } else {
+                return Promise.resolve(
+                    util.format(this.fulfilledMessage, port)
+                );
+            }
+        });
     }
 }

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -265,7 +265,7 @@ export class Preview extends Setup {
         return Promise.resolve();
     }
 
-    public async launchPreview(): Promise<boolean> {
+    public async launchPreview(): Promise<void> {
         // At this point all of the inputs/parameters have been verified and parsed so we can just use them.
 
         let appBundlePath: string | undefined;
@@ -342,7 +342,7 @@ export class Preview extends Setup {
         targetApp: string,
         appConfig: IOSAppPreviewConfig | undefined,
         serverPort: string
-    ): Promise<boolean> {
+    ): Promise<void> {
         const launcher = new IOSLauncher(deviceName);
 
         return launcher.launchPreview(
@@ -363,7 +363,7 @@ export class Preview extends Setup {
         targetApp: string,
         appConfig: AndroidAppPreviewConfig | undefined,
         serverPort: string
-    ): Promise<boolean> {
+    ): Promise<void> {
         const launcher = new AndroidLauncher(deviceName);
 
         return launcher.launchPreview(

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -154,17 +154,17 @@ export class Preview extends Setup {
             PreviewUtils.BROWSER_TARGET_APP
         );
 
-        this.projectDir = CommandLineUtils.resolveFlag(
-            this.flags.projectdir,
-            process.cwd()
+        this.projectDir = CommonUtils.resolveUserHomePath(
+            CommandLineUtils.resolveFlag(this.flags.projectdir, process.cwd())
         );
 
-        const configFileName = CommandLineUtils.resolveFlag(
-            this.flags.configfile,
-            ''
-        ).trim();
+        const configFileName = CommonUtils.resolveUserHomePath(
+            CommandLineUtils.resolveFlag(this.flags.configfile, '')
+        );
 
-        this.configFilePath = path.resolve(this.projectDir, configFileName);
+        this.configFilePath = path.normalize(
+            path.resolve(this.projectDir, configFileName)
+        );
 
         const hasConfigFile =
             this.configFilePath.length > 0 &&

--- a/src/common/AndroidEnvironmentSetup.ts
+++ b/src/common/AndroidEnvironmentSetup.ts
@@ -50,22 +50,20 @@ export class AndroidSDKRootSetRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            const root = AndroidSDKUtils.getAndroidSdkRoot();
-            if (root) {
-                resolve(
-                    AndroidSDKUtils.convertToUnixPath(
-                        util.format(
-                            this.fulfilledMessage,
-                            root.rootSource,
-                            root.rootLocation
-                        )
+        const root = AndroidSDKUtils.getAndroidSdkRoot();
+        if (root) {
+            return Promise.resolve(
+                AndroidSDKUtils.convertToUnixPath(
+                    util.format(
+                        this.fulfilledMessage,
+                        root.rootSource,
+                        root.rootLocation
                     )
-                );
-            } else {
-                reject(this.unfulfilledMessage);
-            }
-        });
+                )
+            );
+        } else {
+            return Promise.reject(this.unfulfilledMessage);
+        }
     }
 }
 

--- a/src/common/AndroidEnvironmentSetup.ts
+++ b/src/common/AndroidEnvironmentSetup.ts
@@ -90,15 +90,13 @@ export class Java8AvailableRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            AndroidSDKUtils.androidSDKPrerequisitesCheck()
-                .then((result) => {
-                    resolve(this.fulfilledMessage);
-                })
-                .catch((error) => {
-                    reject(util.format(this.unfulfilledMessage, error.message));
-                });
-        });
+        return AndroidSDKUtils.androidSDKPrerequisitesCheck()
+            .then((result) => Promise.resolve(this.fulfilledMessage))
+            .catch((error) =>
+                Promise.reject(
+                    util.format(this.unfulfilledMessage, error.message)
+                )
+            );
     }
 }
 
@@ -121,17 +119,15 @@ export class AndroidSDKToolsInstalledRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            AndroidSDKUtils.fetchAndroidCmdLineToolsLocation()
-                .then((result) =>
-                    resolve(
-                        AndroidSDKUtils.convertToUnixPath(
-                            util.format(this.fulfilledMessage, result)
-                        )
+        return AndroidSDKUtils.fetchAndroidCmdLineToolsLocation()
+            .then((result) =>
+                Promise.resolve(
+                    AndroidSDKUtils.convertToUnixPath(
+                        util.format(this.fulfilledMessage, result)
                     )
                 )
-                .catch((error) => reject(this.unfulfilledMessage));
-        });
+            )
+            .catch((error) => Promise.reject(this.unfulfilledMessage));
     }
 }
 
@@ -155,33 +151,32 @@ export class AndroidSDKPlatformToolsInstalledRequirement
     }
 
     public async checkFunction(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            AndroidSDKUtils.fetchAndroidSDKPlatformToolsLocation()
-                .then((result) => {
-                    resolve(
-                        AndroidSDKUtils.convertToUnixPath(
-                            util.format(this.fulfilledMessage, result)
+        return AndroidSDKUtils.fetchAndroidSDKPlatformToolsLocation()
+            .then((result) =>
+                Promise.resolve(
+                    AndroidSDKUtils.convertToUnixPath(
+                        util.format(this.fulfilledMessage, result)
+                    )
+                )
+            )
+            .catch((error) => {
+                if (error.status === 127) {
+                    return Promise.reject(
+                        new Error(
+                            'Platform tools not found. Expected at ' +
+                                AndroidSDKUtils.getAndroidPlatformTools() +
+                                '.'
                         )
                     );
-                })
-                .catch((error) => {
-                    if (error.status === 127) {
-                        reject(
-                            new Error(
-                                'Platform tools not found. Expected at ' +
-                                    AndroidSDKUtils.getAndroidPlatformTools() +
-                                    '.'
-                            )
-                        );
-                    }
-                    reject(
+                } else {
+                    return Promise.reject(
                         util.format(
                             this.unfulfilledMessage,
                             androidConfig.minSupportedRuntimeAndroid
                         )
                     );
-                });
-        });
+                }
+            });
     }
 }
 
@@ -204,22 +199,20 @@ export class PlatformAPIPackageRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            AndroidSDKUtils.findRequiredAndroidAPIPackage()
-                .then((result) =>
-                    resolve(
-                        util.format(this.fulfilledMessage, result.platformAPI)
+        return AndroidSDKUtils.findRequiredAndroidAPIPackage()
+            .then((result) =>
+                Promise.resolve(
+                    util.format(this.fulfilledMessage, result.platformAPI)
+                )
+            )
+            .catch((error) =>
+                Promise.reject(
+                    util.format(
+                        this.unfulfilledMessage,
+                        androidConfig.minSupportedRuntimeAndroid
                     )
                 )
-                .catch((error) =>
-                    reject(
-                        util.format(
-                            this.unfulfilledMessage,
-                            androidConfig.minSupportedRuntimeAndroid
-                        )
-                    )
-                );
-        });
+            );
     }
 }
 
@@ -242,28 +235,17 @@ export class EmulatorImagesRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            AndroidSDKUtils.findRequiredEmulatorImages()
-                .then((result) =>
-                    resolve(util.format(this.fulfilledMessage, result.path))
-                )
-                .catch((error) =>
-                    reject(
-                        util.format(
-                            this.unfulfilledMessage,
-                            androidConfig.supportedImages.join(',')
-                        )
+        return AndroidSDKUtils.findRequiredEmulatorImages()
+            .then((result) =>
+                Promise.resolve(util.format(this.fulfilledMessage, result.path))
+            )
+            .catch((error) =>
+                Promise.reject(
+                    util.format(
+                        this.unfulfilledMessage,
+                        androidConfig.supportedImages.join(',')
                     )
-                );
-        });
+                )
+            );
     }
 }
-
-// test!
-// Messages.importMessagesDirectory(__dirname);
-// let envSetup = new AndroidEnvironmentSetup(new Logger('test'));
-// envSetup.executeSetup().then( (result) => {
-//     console.log(result)
-// }).catch( error => {
-//     console.log(error)
-// });

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -106,13 +106,3 @@ export class AndroidLauncher {
             });
     }
 }
-
-// let launcher = new AndroidLauncher('testemu7');
-// launcher
-//     .launchNativeBrowser('http://salesforce.com/')
-//     .then((result) => {
-//         console.log('Its all cool!');
-//     })
-//     .catch((error) => {
-//         console.log(`uh oh! ${error}`);
-//     });

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -30,13 +30,8 @@ export class AndroidLauncher {
         const androidApi = preferredPack.platformAPI;
         const abi = preferredPack.abi;
         const device = androidConfig.supportedDevices[0];
-        let requestedPort = await AndroidSDKUtils.getNextAndroidAdbPort();
+        const requestedPort = await AndroidSDKUtils.getNextAndroidAdbPort();
         const spinner = cli.action;
-        // need to incr by 2, one for console port and next for adb
-        requestedPort =
-            requestedPort < androidConfig.defaultAdbPort
-                ? androidConfig.defaultAdbPort
-                : requestedPort + 2;
         const emuName = this.emulatorName;
         spinner.start(`Launching`, `Searching for ${emuName}`, {
             stdout: true

--- a/src/common/AndroidLauncher.ts
+++ b/src/common/AndroidLauncher.ts
@@ -24,7 +24,7 @@ export class AndroidLauncher {
         targetApp: string,
         appConfig: AndroidAppPreviewConfig | undefined,
         serverPort: string
-    ): Promise<boolean> {
+    ): Promise<void> {
         const preferredPack = await AndroidSDKUtils.findRequiredEmulatorImages();
         const emuImage = preferredPack.platformEmulatorImage || 'default';
         const androidApi = preferredPack.platformAPI;
@@ -48,14 +48,14 @@ export class AndroidLauncher {
                         androidApi,
                         device,
                         abi
-                    ).then((resolve) => true);
+                    );
                 }
                 spinner.start(`Launching`, `Found device ${emuName}`, {
                     stdout: true
                 });
-                return true;
+                return Promise.resolve();
             })
-            .then((resolve) => {
+            .then(() => {
                 spinner.start(`Launching`, `Starting device ${emuName}`, {
                     stdout: true
                 });

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -110,11 +110,9 @@ export class AndroidSDKUtils {
 
         return CommonUtils.executeCommandAsync(
             `${AndroidSDKUtils.getSdkManagerCommand()} --version`
-        )
-            .then((result) =>
-                Promise.resolve(AndroidSDKUtils.getAndroidCmdLineToolsBin())
-            )
-            .catch((error) => Promise.reject(error));
+        ).then((result) =>
+            Promise.resolve(AndroidSDKUtils.getAndroidCmdLineToolsBin())
+        );
     }
 
     public static async fetchAndroidSDKPlatformToolsLocation(): Promise<
@@ -126,11 +124,9 @@ export class AndroidSDKUtils {
 
         return CommonUtils.executeCommandAsync(
             `${AndroidSDKUtils.getAdbShellCommand()} --version`
-        )
-            .then((result) =>
-                Promise.resolve(AndroidSDKUtils.getAndroidPlatformTools())
-            )
-            .catch((error) => Promise.reject(error));
+        ).then((result) =>
+            Promise.resolve(AndroidSDKUtils.getAndroidPlatformTools())
+        );
     }
 
     public static async fetchInstalledPackages(): Promise<AndroidPackages> {
@@ -144,17 +140,15 @@ export class AndroidSDKUtils {
 
         return CommonUtils.executeCommandAsync(
             `${AndroidSDKUtils.getSdkManagerCommand()} --list`
-        )
-            .then((result) => {
-                if (result.stdout && result.stdout.length > 0) {
-                    const packages = AndroidPackages.parseRawPackagesString(
-                        result.stdout
-                    );
-                    AndroidSDKUtils.packageCache = packages;
-                }
-                return Promise.resolve(AndroidSDKUtils.packageCache);
-            })
-            .catch((error) => Promise.reject(error));
+        ).then((result) => {
+            if (result.stdout && result.stdout.length > 0) {
+                const packages = AndroidPackages.parseRawPackagesString(
+                    result.stdout
+                );
+                AndroidSDKUtils.packageCache = packages;
+            }
+            return Promise.resolve(AndroidSDKUtils.packageCache);
+        });
     }
 
     public static async fetchEmulators(): Promise<AndroidVirtualDevice[]> {
@@ -415,9 +409,9 @@ export class AndroidSDKUtils {
         emulatorPort: number
     ): Promise<void> {
         const openUrlCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} shell am start -a android.intent.action.VIEW -d ${url}`;
-        return CommonUtils.executeCommandAsync(openUrlCommand)
-            .then(() => Promise.resolve())
-            .catch((error) => Promise.reject(error));
+        return CommonUtils.executeCommandAsync(openUrlCommand).then(() =>
+            Promise.resolve()
+        );
     }
 
     public static async launchNativeApp(
@@ -474,8 +468,7 @@ export class AndroidSDKUtils {
 
                 return CommonUtils.executeCommandAsync(launchCommand);
             })
-            .then(() => Promise.resolve())
-            .catch((error) => Promise.reject(error));
+            .then(() => Promise.resolve());
     }
 
     public static getEmulatorPort(
@@ -484,7 +477,7 @@ export class AndroidSDKUtils {
     ): number {
         // if config file does not exist, its created but not launched so use the requestedPortNumber
         // else we will read it from emu-launch-params.txt file.
-        const launchFileName = CommonUtils.resolvePath(
+        const launchFileName = CommonUtils.resolveUserHomePath(
             path.join(
                 `~`,
                 '.android',
@@ -777,7 +770,7 @@ export class AndroidSDKUtils {
                 : `ps -ax | grep qemu-system-x86_64 | grep ${emulatorName} | grep -v grep`;
 
         // ram.img.dirty is a one byte file created when avd is started and removed when avd is stopped.
-        const launchFileName = CommonUtils.resolvePath(
+        const launchFileName = CommonUtils.resolveUserHomePath(
             path.join(
                 `~`,
                 '.android',
@@ -856,7 +849,7 @@ export class AndroidSDKUtils {
     private static async readEmulatorConfig(
         emulatorName: string
     ): Promise<Map<string, string>> {
-        const filePath = CommonUtils.resolvePath(
+        const filePath = CommonUtils.resolveUserHomePath(
             path.join(
                 `~`,
                 '.android',
@@ -893,7 +886,7 @@ export class AndroidSDKUtils {
         config.forEach((value, key) => {
             configString += key + '=' + value + '\n';
         });
-        const filePath = CommonUtils.resolvePath(
+        const filePath = CommonUtils.resolveUserHomePath(
             path.join(
                 `~`,
                 '.android',

--- a/src/common/AndroidUtils.ts
+++ b/src/common/AndroidUtils.ts
@@ -24,8 +24,6 @@ const spawn = childProcess.spawn;
 type StdioOptions = childProcess.StdioOptions;
 
 const LOGGER_NAME = 'force:lightning:mobile:android';
-const USER_HOME =
-    process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
 const WINDOWS_OS = 'win32';
 const ANDROID_SDK_MANAGER_NAME = 'sdkmanager';
 const ANDROID_AVD_MANAGER_NAME = 'avdmanager';
@@ -74,78 +72,65 @@ export class AndroidSDKUtils {
     }
 
     public static async androidSDKPrerequisitesCheck(): Promise<string> {
-        return new Promise(async (resolve, reject) => {
-            // Attempt to run sdkmanager and see if it throws any exceptions.
-            // If no errors are encountered then all prerequisites are met.
-            // But if an error is encountered then we'll try to see if it
-            // is due to unsupported Java version or something else.
-            AndroidSDKUtils.fetchAndroidCmdLineToolsLocation([
-                'ignore', // stdin
-                'pipe', // stdout
-                'pipe' // stderr
-            ])
-                .then((result) => resolve(result))
-                .catch((error) => {
-                    const e: Error = error;
-                    const stack = e.stack || '';
-                    const idx = stack.indexOf(
-                        'java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema'
-                    );
+        // Attempt to run sdkmanager and see if it throws any exceptions.
+        // If no errors are encountered then all prerequisites are met.
+        // But if an error is encountered then we'll try to see if it
+        // is due to unsupported Java version or something else.
+        return AndroidSDKUtils.fetchAndroidCmdLineToolsLocation()
+            .then((result) => Promise.resolve(result))
+            .catch((error) => {
+                const e: Error = error;
+                const stack = e.stack || '';
+                const idx = stack.indexOf(
+                    'java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema'
+                );
 
-                    if (!AndroidSDKUtils.isJavaHomeSet()) {
-                        reject(new Error('JAVA_HOME is not set.'));
-                    } else if (idx !== -1) {
-                        reject(new Error('unsupported Java version.'));
-                    } else if (error.status && error.status === 127) {
-                        reject(
-                            new Error(
-                                `SDK Manager not found. Expected at ${AndroidSDKUtils.getSdkManagerCommand()}`
-                            )
-                        );
-                    } else {
-                        reject(error);
-                    }
-                });
-        });
+                if (!AndroidSDKUtils.isJavaHomeSet()) {
+                    return Promise.reject(new Error('JAVA_HOME is not set.'));
+                } else if (idx !== -1) {
+                    return Promise.reject(
+                        new Error('unsupported Java version.')
+                    );
+                } else if (error.status && error.status === 127) {
+                    return Promise.reject(
+                        new Error(
+                            `SDK Manager not found. Expected at ${AndroidSDKUtils.getSdkManagerCommand()}`
+                        )
+                    );
+                } else {
+                    return Promise.reject(error);
+                }
+            });
     }
 
-    public static async fetchAndroidCmdLineToolsLocation(
-        stdioOptions: StdioOptions = ['ignore', 'pipe', 'ignore']
-    ): Promise<string> {
-        return new Promise(async (resolve, reject) => {
-            if (!AndroidSDKUtils.getAndroidSdkRoot()) {
-                reject(new Error('Android SDK root is not set.'));
-                return;
-            }
-            try {
-                CommonUtils.executeCommandSync(
-                    `${AndroidSDKUtils.getSdkManagerCommand()} --version`,
-                    stdioOptions
-                );
-                resolve(AndroidSDKUtils.getAndroidCmdLineToolsBin());
-            } catch (err) {
-                reject(err);
-                return;
-            }
-        });
+    public static async fetchAndroidCmdLineToolsLocation(): Promise<string> {
+        if (!AndroidSDKUtils.getAndroidSdkRoot()) {
+            return Promise.reject(new Error('Android SDK root is not set.'));
+        }
+
+        return CommonUtils.executeCommandAsync(
+            `${AndroidSDKUtils.getSdkManagerCommand()} --version`
+        )
+            .then((result) =>
+                Promise.resolve(AndroidSDKUtils.getAndroidCmdLineToolsBin())
+            )
+            .catch((error) => Promise.reject(error));
     }
 
     public static async fetchAndroidSDKPlatformToolsLocation(): Promise<
         string
     > {
-        return new Promise(async (resolve, reject) => {
-            if (!AndroidSDKUtils.getAndroidSdkRoot()) {
-                return reject(new Error('Android SDK root is not set.'));
-            }
-            try {
-                CommonUtils.executeCommandSync(
-                    `${AndroidSDKUtils.getAdbShellCommand()} --version`
-                );
-                resolve(AndroidSDKUtils.getAndroidPlatformTools());
-            } catch (err) {
-                reject(err);
-            }
-        });
+        if (!AndroidSDKUtils.getAndroidSdkRoot()) {
+            return Promise.reject(new Error('Android SDK root is not set.'));
+        }
+
+        return CommonUtils.executeCommandAsync(
+            `${AndroidSDKUtils.getAdbShellCommand()} --version`
+        )
+            .then((result) =>
+                Promise.resolve(AndroidSDKUtils.getAndroidPlatformTools())
+            )
+            .catch((error) => Promise.reject(error));
     }
 
     public static async fetchInstalledPackages(): Promise<AndroidPackages> {
@@ -154,157 +139,147 @@ export class AndroidSDKUtils {
         }
 
         if (!AndroidSDKUtils.isCached()) {
-            try {
-                const stdout = CommonUtils.executeCommandSync(
-                    `${AndroidSDKUtils.getSdkManagerCommand()} --list`
-                );
-                if (stdout) {
-                    const packages = AndroidPackages.parseRawPackagesString(
-                        stdout
-                    );
-                    AndroidSDKUtils.packageCache = packages;
-                }
-            } catch (err) {
-                return Promise.reject(err);
-            }
+            return CommonUtils.executeCommandAsync(
+                `${AndroidSDKUtils.getSdkManagerCommand()} --list`
+            )
+                .then((result) => {
+                    if (result.stdout && result.stdout.length > 0) {
+                        const packages = AndroidPackages.parseRawPackagesString(
+                            result.stdout
+                        );
+                        AndroidSDKUtils.packageCache = packages;
+                    }
+                    return Promise.resolve(AndroidSDKUtils.packageCache);
+                })
+                .catch((error) => Promise.reject(error));
+        } else {
+            return Promise.resolve(AndroidSDKUtils.packageCache);
         }
-
-        return Promise.resolve(AndroidSDKUtils.packageCache);
     }
 
-    public static fetchEmulators(): Promise<AndroidVirtualDevice[]> {
-        return new Promise((resolve, reject) => {
-            let devices: AndroidVirtualDevice[] = [];
-            try {
-                const result = CommonUtils.executeCommandSync(
-                    AndroidSDKUtils.getAvdManagerCommand() + ' list avd'
-                );
-                if (result) {
+    public static async fetchEmulators(): Promise<AndroidVirtualDevice[]> {
+        let devices: AndroidVirtualDevice[] = [];
+        return CommonUtils.executeCommandAsync(
+            AndroidSDKUtils.getAvdManagerCommand() + ' list avd'
+        )
+            .then((result) => {
+                if (result.stdout && result.stdout.length > 0) {
                     devices = AndroidVirtualDevice.parseRawString(
-                        result.toString()
+                        result.stdout
                     );
                 }
-            } catch (exception) {
+                return Promise.resolve(devices);
+            })
+            .catch((exception) => {
                 AndroidSDKUtils.logger.warn(exception);
-            }
-            return resolve(devices);
-        });
+                return Promise.resolve(devices);
+            });
     }
 
     public static async findRequiredAndroidAPIPackage(): Promise<
         AndroidPackage
     > {
-        try {
-            const minSupportedRuntimeAndroid = Version.from(
-                androidConfig.minSupportedRuntimeAndroid
-            );
+        const minSupportedRuntimeAndroid = Version.from(
+            androidConfig.minSupportedRuntimeAndroid
+        );
 
-            const packages = await AndroidSDKUtils.fetchInstalledPackages();
-            if (packages.isEmpty()) {
-                return Promise.reject(
-                    new Error(
-                        `No Android API packages are installed. Minimum supported Android API package version is ${androidConfig.minSupportedRuntimeAndroid}`
-                    )
-                );
-            }
-
-            const matchingPlatforms = packages.platforms.filter((pkg) =>
-                pkg.version.sameOrNewer(minSupportedRuntimeAndroid)
-            );
-            if (matchingPlatforms.length < 1) {
-                return Promise.reject(
-                    new Error(
-                        `Could not locate a supported Android API package. Minimum supported Android API package version is ${androidConfig.minSupportedRuntimeAndroid}`
-                    )
-                );
-            }
-
-            // Sort the packages with latest version by negating the comparison result
-            matchingPlatforms.sort((a, b) => a.version.compare(b.version) * -1);
-
-            // Return the latest package that also has matching emulator images
-            for (const platform of matchingPlatforms) {
-                const emulatorImage = await AndroidSDKUtils.packageWithRequiredEmulatorImages(
-                    platform
-                );
-
-                if (emulatorImage) {
-                    return platform;
+        return AndroidSDKUtils.fetchInstalledPackages()
+            .then(async (packages) => {
+                if (packages.isEmpty()) {
+                    return Promise.reject(
+                        new Error(
+                            `No Android API packages are installed. Minimum supported Android API package version is ${androidConfig.minSupportedRuntimeAndroid}`
+                        )
+                    );
                 }
-            }
 
-            // If we got here then it means that we don't have any Android API packages with emulator images.
-            // So we will go ahead and return the latest one anyway. This is b/c the setup command will error
-            // out stating that no packages with matching emulator images have been found so the user would
-            // then know that they should install emulator images for the latest API package.
-            return matchingPlatforms[0];
-        } catch (error) {
-            return Promise.reject(
-                new Error(
-                    `Could not find android api packages. ${error.errorMessage}`
+                const matchingPlatforms = packages.platforms.filter((pkg) =>
+                    pkg.version.sameOrNewer(minSupportedRuntimeAndroid)
+                );
+                if (matchingPlatforms.length < 1) {
+                    return Promise.reject(
+                        new Error(
+                            `Could not locate a supported Android API package. Minimum supported Android API package version is ${androidConfig.minSupportedRuntimeAndroid}`
+                        )
+                    );
+                }
+
+                // Sort the packages with latest version by negating the comparison result
+                matchingPlatforms.sort(
+                    (a, b) => a.version.compare(b.version) * -1
+                );
+
+                // Return the latest package that also has matching emulator images
+                for (const platform of matchingPlatforms) {
+                    const emulatorImage = await AndroidSDKUtils.packageWithRequiredEmulatorImages(
+                        platform
+                    );
+
+                    if (emulatorImage) {
+                        return Promise.resolve(platform);
+                    }
+                }
+
+                // If we got here then it means that we don't have any Android API packages with emulator images.
+                // So we will go ahead and return the latest one anyway. This is b/c the setup command will error
+                // out stating that no packages with matching emulator images have been found so the user would
+                // then know that they should install emulator images for the latest API package.
+                return Promise.resolve(matchingPlatforms[0]);
+            })
+            .catch((error) =>
+                Promise.reject(
+                    new Error(
+                        `Could not find android api packages. ${error.errorMessage}`
+                    )
                 )
             );
-        }
     }
 
     public static async findRequiredEmulatorImages(): Promise<AndroidPackage> {
-        try {
-            const installedAndroidPackage = await AndroidSDKUtils.findRequiredAndroidAPIPackage();
-            const emulatorImage = await AndroidSDKUtils.packageWithRequiredEmulatorImages(
-                installedAndroidPackage
-            );
+        let installedAndroidPackage: AndroidPackage;
 
-            if (emulatorImage) {
-                return Promise.resolve(emulatorImage);
-            } else {
-                return Promise.reject(
-                    new Error(
-                        `Could not locate an emulator image. Requires any one of these [${androidConfig.supportedImages.join(
-                            ','
-                        )} for ${[installedAndroidPackage.platformAPI]}]`
-                    )
+        return AndroidSDKUtils.findRequiredAndroidAPIPackage()
+            .then((pkg) => {
+                installedAndroidPackage = pkg;
+                return AndroidSDKUtils.packageWithRequiredEmulatorImages(
+                    installedAndroidPackage
                 );
-            }
-        } catch (error) {
-            return Promise.reject(
-                new Error(`Could not find android emulator packages.`)
-            );
-        }
-    }
-
-    public static getNextAndroidAdbPort(): Promise<number> {
-        const command = `${AndroidSDKUtils.getAdbShellCommand()} devices`;
-        return new Promise<number>((resolve, reject) => {
-            let adbPort = 0;
-            try {
-                const stdout = CommonUtils.executeCommandSync(command);
-                let listOfDevices: number[] = stdout
-                    .toString()
-                    .split(os.EOL)
-                    .filter((avd: string) =>
-                        avd.toLowerCase().startsWith('emulator')
-                    )
-                    .map((value) => {
-                        const array = value.match(/\d+/);
-                        const portNumbers = array ? array.map(Number) : [0];
-                        return portNumbers[0];
-                    });
-                if (listOfDevices && listOfDevices.length > 0) {
-                    listOfDevices = listOfDevices.sort().reverse();
-                    adbPort = listOfDevices[0];
+            })
+            .then((emulatorImage) => {
+                if (emulatorImage) {
+                    return Promise.resolve(emulatorImage);
+                } else {
+                    return Promise.reject(
+                        new Error(
+                            `Could not locate an emulator image. Requires any one of these [${androidConfig.supportedImages.join(
+                                ','
+                            )} for ${[installedAndroidPackage.platformAPI]}]`
+                        )
+                    );
                 }
-            } catch (exception) {
-                AndroidSDKUtils.logger.error(exception);
-            }
-            return resolve(adbPort);
-        });
+            })
+            .catch((error) =>
+                Promise.reject(
+                    new Error(`Could not find android emulator packages.`)
+                )
+            );
     }
 
-    public static hasEmulator(emulatorName: string): Promise<boolean> {
-        const resolvedEmulator = AndroidSDKUtils.resolveEmulatorImage(
-            emulatorName
+    public static async getNextAndroidAdbPort(): Promise<number> {
+        // need to incr by 2, one for console port and next for adb
+        return AndroidSDKUtils.getCurrentAdbPort().then((adbPort) =>
+            adbPort < androidConfig.defaultAdbPort
+                ? Promise.resolve(androidConfig.defaultAdbPort)
+                : Promise.resolve(adbPort + 2)
         );
-        return Promise.resolve(resolvedEmulator !== undefined);
+    }
+
+    public static async hasEmulator(emulatorName: string): Promise<boolean> {
+        return AndroidSDKUtils.resolveEmulatorImage(
+            emulatorName
+        ).then((resolvedEmulator) =>
+            Promise.resolve(resolvedEmulator !== undefined)
+        );
     }
 
     public static async createNewVirtualDevice(
@@ -362,50 +337,47 @@ export class AndroidSDKUtils {
         );
     }
 
-    public static startEmulator(
+    public static async startEmulator(
         emulatorName: string,
         requestedPortNumber: number
     ): Promise<number> {
-        return new Promise<number>((resolve, reject) => {
-            let portNumber = requestedPortNumber;
-            const resolvedEmulator = AndroidSDKUtils.resolveEmulatorImage(
-                emulatorName
-            );
+        return AndroidSDKUtils.resolveEmulatorImage(emulatorName).then(
+            (resolvedEmulator) => {
+                // This shouldn't happen b/c we make sure an emulator exists
+                // before calling this method, but keeping it just in case
+                if (resolvedEmulator === undefined) {
+                    return Promise.reject(
+                        new Error(`Invalid emulator: ${emulatorName}`)
+                    );
+                }
 
-            // This shouldn't happen b/c we make ensure an emulator exists
-            // before calling this method, but keeping it just in case
-            if (resolvedEmulator === undefined) {
-                reject(new Error(`Invalid emulator: ${emulatorName}`));
-                return;
-            }
-
-            try {
                 if (
-                    AndroidSDKUtils.isEmulatorAlreadyStarted(resolvedEmulator)
+                    AndroidSDKUtils.isEmulatorAlreadyRunning(resolvedEmulator)
                 ) {
                     // get port number from emu-launch-params.txt
-                    portNumber = AndroidSDKUtils.getEmulatorPort(
+                    const portNumber = AndroidSDKUtils.getEmulatorPort(
                         resolvedEmulator,
                         requestedPortNumber
                     );
-                    resolve(portNumber);
-                    return;
+                    return Promise.resolve(portNumber);
                 }
 
-                // We intentionally use spawn and ignore stdio here b/c emulator command can
-                // spit out a bunch of output to stderr where they are not really errors. This
-                // is specially true on Windows platform. So istead we spawn the process to launch
-                // the emulator and later attempt at polling the emulator to see if it failed to boot.
-                const child = spawn(
-                    `${AndroidSDKUtils.getEmulatorCommand()} @${resolvedEmulator} -port ${portNumber}`,
-                    { detached: true, shell: true, stdio: 'ignore' }
-                );
-                resolve(portNumber);
-                child.unref();
-            } catch (error) {
-                reject(error);
+                try {
+                    // We intentionally use spawn and ignore stdio here b/c emulator command can
+                    // spit out a bunch of output to stderr where they are not really errors. This
+                    // is specially true on Windows platform. So istead we spawn the process to launch
+                    // the emulator and later attempt at polling the emulator to see if it failed to boot.
+                    const child = spawn(
+                        `${AndroidSDKUtils.getEmulatorCommand()} @${resolvedEmulator} -port ${requestedPortNumber}`,
+                        { detached: true, shell: true, stdio: 'ignore' }
+                    );
+                    child.unref();
+                    return Promise.resolve(requestedPortNumber);
+                } catch (error) {
+                    return Promise.reject(error);
+                }
             }
-        });
+        );
     }
 
     public static async pollDeviceStatus(portNumber: number): Promise<boolean> {
@@ -446,22 +418,17 @@ export class AndroidSDKUtils {
         });
     }
 
-    public static launchURLIntent(
+    public static async launchURLIntent(
         url: string,
         emulatorPort: number
     ): Promise<boolean> {
         const openUrlCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} shell am start -a android.intent.action.VIEW -d ${url}`;
-        return new Promise((resolve, reject) => {
-            try {
-                CommonUtils.executeCommandSync(openUrlCommand);
-                resolve(true);
-            } catch (error) {
-                reject(error);
-            }
-        });
+        return CommonUtils.executeCommandAsync(openUrlCommand)
+            .then((result) => Promise.resolve(true))
+            .catch((error) => Promise.reject(error));
     }
 
-    public static launchNativeApp(
+    public static async launchNativeApp(
         compName: string,
         projectDir: string,
         appBundlePath: string | undefined,
@@ -472,48 +439,51 @@ export class AndroidSDKUtils {
         serverAddress: string | undefined,
         serverPort: string | undefined
     ): Promise<boolean> {
-        try {
-            if (appBundlePath && appBundlePath.trim().length > 0) {
-                AndroidSDKUtils.logger.info(
-                    `Installing app ${appBundlePath.trim()} to emulator`
-                );
-                const pathQuote = process.platform === WINDOWS_OS ? '"' : "'";
-                const installCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} install -r -t ${pathQuote}${appBundlePath.trim()}${pathQuote}`;
-                CommonUtils.executeCommandSync(installCommand);
-            }
-
-            let launchArgs =
-                `--es "${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}" "${compName}"` +
-                ` --es "${PreviewUtils.PROJECT_DIR_ARG_PREFIX}" "${projectDir}"`;
-
-            if (serverAddress) {
-                launchArgs += ` --es "${PreviewUtils.SERVER_ADDRESS_PREFIX}" "${serverAddress}"`;
-            }
-
-            if (serverPort) {
-                launchArgs += ` --es "${PreviewUtils.SERVER_PORT_PREFIX}" "${serverPort}"`;
-            }
-
-            targetAppArguments.forEach((arg) => {
-                launchArgs += ` --es "${arg.name}" "${arg.value}"`;
-            });
-
-            const launchCommand =
-                `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort}` +
-                ` shell am start -S -n "${targetApp}/${launchActivity}"` +
-                ' -a android.intent.action.MAIN' +
-                ' -c android.intent.category.LAUNCHER' +
-                ` ${launchArgs}`;
-
+        let thePromise: Promise<{ stdout: string; stderr: string }>;
+        if (appBundlePath && appBundlePath.trim().length > 0) {
             AndroidSDKUtils.logger.info(
-                `Relaunching app ${targetApp} in emulator`
+                `Installing app ${appBundlePath.trim()} to emulator`
             );
-            CommonUtils.executeCommandSync(launchCommand);
-
-            return Promise.resolve(true);
-        } catch (error) {
-            return Promise.reject(error);
+            const pathQuote = process.platform === WINDOWS_OS ? '"' : "'";
+            const installCommand = `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort} install -r -t ${pathQuote}${appBundlePath.trim()}${pathQuote}`;
+            thePromise = CommonUtils.executeCommandAsync(installCommand);
+        } else {
+            thePromise = Promise.resolve({ stdout: '', stderr: '' });
         }
+
+        return thePromise
+            .then((result) => {
+                let launchArgs =
+                    `--es "${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}" "${compName}"` +
+                    ` --es "${PreviewUtils.PROJECT_DIR_ARG_PREFIX}" "${projectDir}"`;
+
+                if (serverAddress) {
+                    launchArgs += ` --es "${PreviewUtils.SERVER_ADDRESS_PREFIX}" "${serverAddress}"`;
+                }
+
+                if (serverPort) {
+                    launchArgs += ` --es "${PreviewUtils.SERVER_PORT_PREFIX}" "${serverPort}"`;
+                }
+
+                targetAppArguments.forEach((arg) => {
+                    launchArgs += ` --es "${arg.name}" "${arg.value}"`;
+                });
+
+                const launchCommand =
+                    `${AndroidSDKUtils.getAdbShellCommand()} -s emulator-${emulatorPort}` +
+                    ` shell am start -S -n "${targetApp}/${launchActivity}"` +
+                    ' -a android.intent.action.MAIN' +
+                    ' -c android.intent.category.LAUNCHER' +
+                    ` ${launchArgs}`;
+
+                AndroidSDKUtils.logger.info(
+                    `Relaunching app ${targetApp} in emulator`
+                );
+
+                return CommonUtils.executeCommandAsync(launchCommand);
+            })
+            .then((result) => Promise.resolve(true))
+            .catch((error) => Promise.reject(error));
     }
 
     public static getEmulatorPort(
@@ -522,12 +492,14 @@ export class AndroidSDKUtils {
     ): number {
         // if config file does not exist, its created but not launched so use the requestedPortNumber
         // else we will read it from emu-launch-params.txt file.
-        const launchFileName = path.join(
-            `${USER_HOME}`,
-            '.android',
-            'avd',
-            `${emulatorName}.avd`,
-            'emu-launch-params.txt'
+        const launchFileName = CommonUtils.resolvePath(
+            path.join(
+                `~`,
+                '.android',
+                'avd',
+                `${emulatorName}.avd`,
+                'emu-launch-params.txt'
+            )
         );
         let adjustedPort = requestedPortNumber;
         if (fs.existsSync(launchFileName)) {
@@ -559,7 +531,9 @@ export class AndroidSDKUtils {
     }
 
     // This method is public for testing purposes.
-    public static updateEmulatorConfig(emulatorName: string): Promise<boolean> {
+    public static async updateEmulatorConfig(
+        emulatorName: string
+    ): Promise<boolean> {
         return new Promise(async (resolve, reject) => {
             const config = await AndroidSDKUtils.readEmulatorConfig(
                 emulatorName
@@ -638,30 +612,7 @@ export class AndroidSDKUtils {
         return AndroidSDKUtils.sdkRoot;
     }
 
-    private static logger: Logger = new Logger(LOGGER_NAME);
-    private static packageCache: AndroidPackages = new AndroidPackages();
-    private static emulatorCommand: string | undefined;
-    private static androidCmdLineToolsBin: string | undefined;
-    private static androidPlatformTools: string | undefined;
-    private static avdManagerCommand: string | undefined;
-    private static adbShellCommand: string | undefined;
-    private static sdkManagerCommand: string | undefined;
-    private static sdkRoot: AndroidSDKRoot | undefined;
-
-    private static getEmulatorCommand(): string {
-        if (!AndroidSDKUtils.emulatorCommand) {
-            const sdkRoot = AndroidSDKUtils.getAndroidSdkRoot();
-            AndroidSDKUtils.emulatorCommand = path.join(
-                (sdkRoot && sdkRoot.rootLocation) || '',
-                'emulator',
-                'emulator'
-            );
-        }
-
-        return AndroidSDKUtils.emulatorCommand;
-    }
-
-    private static getAndroidCmdLineToolsBin(): string {
+    public static getAndroidCmdLineToolsBin(): string {
         if (!AndroidSDKUtils.androidCmdLineToolsBin) {
             const sdkRoot = AndroidSDKUtils.getAndroidSdkRoot();
             AndroidSDKUtils.androidCmdLineToolsBin = path.join(
@@ -699,7 +650,20 @@ export class AndroidSDKUtils {
         return AndroidSDKUtils.androidCmdLineToolsBin;
     }
 
-    private static getAvdManagerCommand(): string {
+    public static getEmulatorCommand(): string {
+        if (!AndroidSDKUtils.emulatorCommand) {
+            const sdkRoot = AndroidSDKUtils.getAndroidSdkRoot();
+            AndroidSDKUtils.emulatorCommand = path.join(
+                (sdkRoot && sdkRoot.rootLocation) || '',
+                'emulator',
+                'emulator'
+            );
+        }
+
+        return AndroidSDKUtils.emulatorCommand;
+    }
+
+    public static getAvdManagerCommand(): string {
         if (!AndroidSDKUtils.avdManagerCommand) {
             AndroidSDKUtils.avdManagerCommand = path.join(
                 AndroidSDKUtils.getAndroidCmdLineToolsBin(),
@@ -710,7 +674,7 @@ export class AndroidSDKUtils {
         return AndroidSDKUtils.avdManagerCommand;
     }
 
-    private static getAdbShellCommand(): string {
+    public static getAdbShellCommand(): string {
         if (!AndroidSDKUtils.adbShellCommand) {
             AndroidSDKUtils.adbShellCommand = path.join(
                 AndroidSDKUtils.getAndroidPlatformTools(),
@@ -721,7 +685,7 @@ export class AndroidSDKUtils {
         return AndroidSDKUtils.adbShellCommand;
     }
 
-    private static getSdkManagerCommand(): string {
+    public static getSdkManagerCommand(): string {
         if (!AndroidSDKUtils.sdkManagerCommand) {
             AndroidSDKUtils.sdkManagerCommand = path.join(
                 AndroidSDKUtils.getAndroidCmdLineToolsBin(),
@@ -730,6 +694,45 @@ export class AndroidSDKUtils {
         }
 
         return AndroidSDKUtils.sdkManagerCommand;
+    }
+
+    private static logger: Logger = new Logger(LOGGER_NAME);
+    private static packageCache: AndroidPackages = new AndroidPackages();
+    private static emulatorCommand: string | undefined;
+    private static androidCmdLineToolsBin: string | undefined;
+    private static androidPlatformTools: string | undefined;
+    private static avdManagerCommand: string | undefined;
+    private static adbShellCommand: string | undefined;
+    private static sdkManagerCommand: string | undefined;
+    private static sdkRoot: AndroidSDKRoot | undefined;
+
+    private static async getCurrentAdbPort(): Promise<number> {
+        let adbPort = 0;
+        const command = `${AndroidSDKUtils.getAdbShellCommand()} devices`;
+        return CommonUtils.executeCommandAsync(command)
+            .then((result) => {
+                if (result.stdout) {
+                    let listOfDevices: number[] = result.stdout
+                        .split(os.EOL)
+                        .filter((avd: string) =>
+                            avd.toLowerCase().startsWith('emulator')
+                        )
+                        .map((value) => {
+                            const array = value.match(/\d+/);
+                            const portNumbers = array ? array.map(Number) : [0];
+                            return portNumbers[0];
+                        });
+                    if (listOfDevices && listOfDevices.length > 0) {
+                        listOfDevices = listOfDevices.sort().reverse();
+                        adbPort = listOfDevices[0];
+                    }
+                }
+                return Promise.resolve(adbPort);
+            })
+            .catch((exception) => {
+                AndroidSDKUtils.logger.error(exception);
+                return Promise.resolve(adbPort);
+            });
     }
 
     private static async packageWithRequiredEmulatorImages(
@@ -777,21 +780,23 @@ export class AndroidSDKUtils {
         );
     }
 
-    private static isEmulatorAlreadyStarted(emulatorName: string): boolean {
+    private static isEmulatorAlreadyRunning(emulatorName: string): boolean {
         const findProcessCommand =
             process.platform === WINDOWS_OS
                 ? `wmic process where "CommandLine Like \'%qemu-system-x86_64%\'" get CommandLine | findstr /V "wmic process where" | findstr "${emulatorName}"`
                 : `ps -ax | grep qemu-system-x86_64 | grep ${emulatorName} | grep -v grep`;
 
         // ram.img.dirty is a one byte file created when avd is started and removed when avd is stopped.
-        const launchFileName = path.join(
-            `${USER_HOME}`,
-            '.android',
-            'avd',
-            `${emulatorName}.avd`,
-            'snapshots',
-            'default_boot',
-            'ram.img.dirty'
+        const launchFileName = CommonUtils.resolvePath(
+            path.join(
+                `~`,
+                '.android',
+                'avd',
+                `${emulatorName}.avd`,
+                'snapshots',
+                'default_boot',
+                'ram.img.dirty'
+            )
         );
 
         // first ensure that ram.img.dirty exists
@@ -830,38 +835,46 @@ export class AndroidSDKUtils {
     // The user can provide us with emulator name as an ID (Pixel_XL) or as display name (Pixel XL).
     // This method can be used to resolve a display name back to an id since emulator commands
     // work with IDs not display names.
-    private static resolveEmulatorImage(
+    private static async resolveEmulatorImage(
         emulatorName: string
-    ): string | undefined {
+    ): Promise<string | undefined> {
         const emulatorDisplayName = emulatorName.replace(/[_-]/gi, ' ').trim(); // eg. Pixel_XL --> Pixel XL, tv-emulator --> tv emulator
 
-        try {
-            const stdout = CommonUtils.executeCommandSync(
-                AndroidSDKUtils.getEmulatorCommand() + ' ' + '-list-avds'
-            );
-            const listOfAVDs = stdout.toString().split(os.EOL);
-            for (const avd of listOfAVDs) {
-                const avdDisplayName = avd.replace(/[_-]/gi, ' ').trim();
+        return CommonUtils.executeCommandAsync(
+            `${AndroidSDKUtils.getEmulatorCommand()} -list-avds`
+        )
+            .then((result) => {
+                const listOfAVDs = result.stdout.split(os.EOL);
+                for (const avd of listOfAVDs) {
+                    const avdDisplayName = avd.replace(/[_-]/gi, ' ').trim();
 
-                if (
-                    avd === emulatorName ||
-                    avdDisplayName === emulatorDisplayName
-                ) {
-                    return avd;
+                    if (
+                        avd === emulatorName ||
+                        avdDisplayName === emulatorDisplayName
+                    ) {
+                        return Promise.resolve(avd.trim());
+                    }
                 }
-            }
-        } catch (exception) {
-            AndroidSDKUtils.logger.error(exception);
-        }
-
-        return undefined;
+                return Promise.resolve(undefined);
+            })
+            .catch((error) => {
+                AndroidSDKUtils.logger.error(error);
+                return Promise.resolve(undefined);
+            });
     }
 
     private static async readEmulatorConfig(
         emulatorName: string
     ): Promise<Map<string, string>> {
-        const filePath =
-            USER_HOME + `/.android/avd/${emulatorName}.avd/config.ini`;
+        const filePath = CommonUtils.resolvePath(
+            path.join(
+                `~`,
+                '.android',
+                'avd',
+                `${emulatorName}.avd`,
+                'config.ini'
+            )
+        );
         try {
             const configFile = fs.readFileSync(filePath, 'utf8');
             const configMap = new Map();
@@ -890,8 +903,15 @@ export class AndroidSDKUtils {
         config.forEach((value, key) => {
             configString += key + '=' + value + '\n';
         });
-        const filePath =
-            USER_HOME + `/.android/avd/${emulatorName}.avd/config.ini`;
+        const filePath = CommonUtils.resolvePath(
+            path.join(
+                `~`,
+                '.android',
+                'avd',
+                `${emulatorName}.avd`,
+                'config.ini'
+            )
+        );
         try {
             fs.writeFileSync(filePath, configString, 'utf8');
         } catch (error) {

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -20,6 +20,10 @@ export class CommonUtils {
         return Promise.resolve();
     }
 
+    public static delay(ms: number): Promise<void> {
+        return new Promise((resolve) => setTimeout(resolve, ms));
+    }
+
     public static resolvePath(inputPath: string): string {
         let newPath = inputPath.trim();
         if (newPath.startsWith('~')) {

--- a/src/common/CommonUtils.ts
+++ b/src/common/CommonUtils.ts
@@ -24,17 +24,16 @@ export class CommonUtils {
         return new Promise((resolve) => setTimeout(resolve, ms));
     }
 
-    public static resolvePath(inputPath: string): string {
+    public static resolveUserHomePath(inputPath: string): string {
         let newPath = inputPath.trim();
         if (newPath.startsWith('~')) {
-            const USER_HOME =
+            const userHome =
                 process.env.HOME ||
                 process.env.HOMEPATH ||
                 process.env.USERPROFILE ||
                 '';
-            newPath = newPath.replace('~', USER_HOME);
+            newPath = newPath.replace('~', userHome);
         }
-        newPath = path.normalize(path.resolve(newPath));
         return newPath;
     }
 
@@ -67,17 +66,18 @@ export class CommonUtils {
                         CommonUtils.logger.error(
                             `Error executing command '${command}':`
                         );
-                        CommonUtils.logger.error(`${error}`);
 
                         // also include stderr & stdout for more detailed error
                         let msg = error.message;
                         if (stderr && stderr.length > 0) {
-                            msg = `${msg}\n${stderr}`;
+                            msg = `${msg}\nstderr:\n${stderr}`;
                         }
                         if (stdout && stdout.length > 0) {
-                            msg = `${msg}\n${stdout}`;
+                            msg = `${msg}\nstdout:\n${stdout}`;
                         }
-                        reject(new Error(msg));
+
+                        CommonUtils.logger.error(msg);
+                        reject(error);
                     } else {
                         resolve({ stdout, stderr });
                     }
@@ -88,9 +88,9 @@ export class CommonUtils {
 
     public static async isLwcServerPluginInstalled(): Promise<void> {
         const command = 'sfdx force:lightning:lwc:start --help';
-        return CommonUtils.executeCommandAsync(command)
-            .then((result) => Promise.resolve())
-            .catch((error) => Promise.reject(error));
+        return CommonUtils.executeCommandAsync(command).then(() =>
+            Promise.resolve()
+        );
     }
 
     public static async getLwcServerPort(): Promise<string | undefined> {

--- a/src/common/IOSEnvironmentSetup.ts
+++ b/src/common/IOSEnvironmentSetup.ts
@@ -167,7 +167,3 @@ export class SupportedSimulatorRuntimeRequirement implements Requirement {
             });
     }
 }
-
-// Test!
-// let envSetup = new IOSEnvironmentSetup();
-// envSetup.executeSetup();

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -4,13 +4,10 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import childProcess from 'child_process';
 import cli from 'cli-ux';
-import util from 'util';
 import { IOSUtils } from './IOSUtils';
 import { IOSAppPreviewConfig, LaunchArgument } from './PreviewConfigFile';
 import { PreviewUtils } from './PreviewUtils';
-const exec = util.promisify(childProcess.exec);
 
 export class IOSLauncher {
     private simulatorName: string;
@@ -112,13 +109,3 @@ export class IOSLauncher {
             });
     }
 }
-
-// let launcher = new IOSLauncher('sfdxdevmobile-101');
-// launcher
-//     .launchNativeBrowser('http://salesforce.com')
-//     .then((result) => {
-//         console.log('Done!');
-//     })
-//     .catch((error) => {
-//         console.log('Error!' + error);
-//     });

--- a/src/common/IOSLauncher.ts
+++ b/src/common/IOSLauncher.ts
@@ -23,7 +23,7 @@ export class IOSLauncher {
         targetApp: string,
         appConfig: IOSAppPreviewConfig | undefined,
         serverPort: string
-    ): Promise<boolean> {
+    ): Promise<void> {
         const availableDevices: string[] = await IOSUtils.getSupportedDevices();
         const supportedRuntimes: string[] = await IOSUtils.getSupportedRuntimes();
         const currentSimulator = await IOSUtils.getSimulator(

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -307,8 +307,7 @@ export class IOSUtils {
                 IOSUtils.logger.info(`Launching app ${targetApp} in simulator`);
                 return CommonUtils.executeCommandAsync(launchCommand);
             })
-            .then(() => Promise.resolve())
-            .catch((error) => Promise.reject(error));
+            .then(() => Promise.resolve());
     }
 
     private static logger: Logger = new Logger(LOGGER_NAME);

--- a/src/common/IOSUtils.ts
+++ b/src/common/IOSUtils.ts
@@ -23,10 +23,10 @@ export class IOSUtils {
         return Promise.resolve();
     }
 
-    public static async bootDevice(udid: string): Promise<boolean> {
+    public static async bootDevice(udid: string): Promise<void> {
         const command = `${XCRUN_CMD} simctl boot ${udid}`;
         return CommonUtils.executeCommandAsync(command)
-            .then((result) => Promise.resolve(true))
+            .then(() => Promise.resolve())
             .catch((error) => {
                 if (!IOSUtils.isDeviceAlreadyBootedError(error)) {
                     return Promise.reject(
@@ -35,7 +35,7 @@ export class IOSUtils {
                         )
                     );
                 } else {
-                    return Promise.resolve(true);
+                    return Promise.resolve();
                 }
             });
     }
@@ -209,10 +209,10 @@ export class IOSUtils {
             });
     }
 
-    public static async waitUntilDeviceIsReady(udid: string): Promise<boolean> {
+    public static async waitUntilDeviceIsReady(udid: string): Promise<void> {
         const command = `${XCRUN_CMD} simctl bootstatus "${udid}"`;
         return CommonUtils.executeCommandAsync(command)
-            .then((result) => Promise.resolve(true))
+            .then(() => Promise.resolve())
             .catch((error) =>
                 Promise.reject(
                     new Error(
@@ -222,10 +222,10 @@ export class IOSUtils {
             );
     }
 
-    public static async launchSimulatorApp(): Promise<boolean> {
+    public static async launchSimulatorApp(): Promise<void> {
         const command = `open -a Simulator`;
         return CommonUtils.executeCommandAsync(command)
-            .then((result) => Promise.resolve(true))
+            .then(() => Promise.resolve())
             .catch((error) =>
                 Promise.reject(
                     new Error(
@@ -238,10 +238,10 @@ export class IOSUtils {
     public static async launchURLInBootedSimulator(
         udid: string,
         url: string
-    ): Promise<boolean> {
+    ): Promise<void> {
         const command = `${XCRUN_CMD} simctl openurl "${udid}" ${url}`;
         return CommonUtils.executeCommandAsync(command)
-            .then((result) => Promise.resolve(true))
+            .then(() => Promise.resolve())
             .catch((error) =>
                 Promise.reject(
                     new Error(
@@ -260,7 +260,7 @@ export class IOSUtils {
         targetAppArguments: LaunchArgument[],
         serverAddress: string | undefined,
         serverPort: string | undefined
-    ): Promise<boolean> {
+    ): Promise<void> {
         let thePromise: Promise<{ stdout: string; stderr: string }>;
         if (appBundlePath && appBundlePath.trim().length > 0) {
             IOSUtils.logger.info(
@@ -273,7 +273,7 @@ export class IOSUtils {
         }
 
         return thePromise
-            .then(async (result) => {
+            .then(async () => {
                 let launchArgs =
                     `${PreviewUtils.COMPONENT_NAME_ARG_PREFIX}=${compName}` +
                     ` ${PreviewUtils.PROJECT_DIR_ARG_PREFIX}=${projectDir}`;
@@ -307,7 +307,7 @@ export class IOSUtils {
                 IOSUtils.logger.info(`Launching app ${targetApp} in simulator`);
                 return CommonUtils.executeCommandAsync(launchCommand);
             })
-            .then((result) => Promise.resolve(true))
+            .then(() => Promise.resolve())
             .catch((error) => Promise.reject(error));
     }
 

--- a/src/common/Requirements.ts
+++ b/src/common/Requirements.ts
@@ -220,13 +220,14 @@ export class LWCServerPluginInstalledRequirement implements Requirement {
     }
 
     public async checkFunction(): Promise<string> {
-        return new Promise<string>(async (resolve, reject) => {
-            try {
-                await CommonUtils.isLwcServerPluginInstalled();
+        return CommonUtils.isLwcServerPluginInstalled()
+            .then(() => {
                 this.logger.info('sfdx server plugin detected.');
-                resolve(this.fulfilledMessage);
-            } catch {
+                return Promise.resolve(this.fulfilledMessage);
+            })
+            .catch((error) => {
                 this.logger.info('sfdx server plugin was not detected.');
+
                 try {
                     const command =
                         'sfdx plugins:install @salesforce/lwc-dev-server';
@@ -239,14 +240,13 @@ export class LWCServerPluginInstalledRequirement implements Requirement {
                         'inherit'
                     ]);
                     this.logger.info('sfdx server plugin installed.');
-                    resolve(this.fulfilledMessage);
+                    return Promise.resolve(this.fulfilledMessage);
                 } catch (error) {
                     this.logger.error(
                         `sfdx server plugin installion failed. ${error}`
                     );
-                    reject(new Error(this.unfulfilledMessage));
+                    return Promise.reject(new Error(this.unfulfilledMessage));
                 }
-            }
-        });
+            });
     }
 }

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -57,9 +57,10 @@ const launchCommandThrowsMock = jest.fn((): string => {
     throw new Error(' Mock Error');
 });
 
-const sdkCommand = path.normalize(
-    mockAndroidHome + '/cmdline-tools/sdkmanager'
+const mockCmdLineToolsBin = path.normalize(
+    path.join(mockAndroidHome, 'cmdline-tools', 'latest', 'bin')
 );
+const sdkCommand = path.normalize(path.join(mockCmdLineToolsBin, 'sdkmanager'));
 const adbCommand = path.normalize(mockAndroidHome + '/platform-tools/adb');
 
 let readFileSpy: jest.SpyInstance<any>;
@@ -75,6 +76,10 @@ describe('Android utils', () => {
                 };
             }
         );
+        jest.spyOn(
+            AndroidSDKUtils,
+            'getAndroidCmdLineToolsBin'
+        ).mockReturnValue(mockCmdLineToolsBin);
         myCommandBlockMock.mockClear();
         badBlockMock.mockClear();
         AndroidSDKUtils.clearCaches();

--- a/src/common/__tests__/AndroidUtils.test.ts
+++ b/src/common/__tests__/AndroidUtils.test.ts
@@ -18,29 +18,40 @@ const mockAndroidSdkRoot = '/mock-android-sdk-root';
 const userHome =
     process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
 
-const myGenericVersionsCommandBlockMock = jest.fn((): string => {
-    return 'mock version 1.0';
-});
+const myGenericVersionsCommandBlockMock = jest.fn(
+    (): Promise<{ stdout: string; stderr: string }> =>
+        Promise.resolve({ stdout: 'mock version 1.0', stderr: '' })
+);
 
-const myGenericVersionsCommandBlockMockThrows = jest.fn((): string => {
-    throw new Error('Command not found!');
-});
+const myGenericVersionsCommandBlockMockThrows = jest.fn(
+    (): Promise<{ stdout: string; stderr: string }> =>
+        Promise.reject(new Error('Command not found!'))
+);
 
-const myCommandBlockMock = jest.fn((): string => {
-    return AndroidMockData.mockRawPackagesString;
-});
+const myCommandBlockMock = jest.fn(
+    (): Promise<{ stdout: string; stderr: string }> =>
+        Promise.resolve({
+            stderr: '',
+            stdout: AndroidMockData.mockRawPackagesString
+        })
+);
 
-const badBlockMock = jest.fn((): string => {
-    return AndroidMockData.badMockRawPackagesString;
-});
+const badBlockMock = jest.fn(
+    (): Promise<{ stdout: string; stderr: string }> =>
+        Promise.resolve({
+            stderr: '',
+            stdout: AndroidMockData.badMockRawPackagesString
+        })
+);
 
 const throwMock = jest.fn((): void => {
     throw new Error('test error');
 });
 
-const launchCommandMock = jest.fn((): string => {
-    return '';
-});
+const launchCommandMock = jest.fn(
+    (): Promise<{ stdout: string; stderr: string }> =>
+        Promise.resolve({ stdout: '', stderr: '' })
+);
 
 const launchCommandThrowsMock = jest.fn((): string => {
     throw new Error(' Mock Error');
@@ -81,35 +92,27 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to verify Android SDK prerequisites are met', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myGenericVersionsCommandBlockMock
         );
         await AndroidSDKUtils.androidSDKPrerequisitesCheck();
-        expect(
-            myGenericVersionsCommandBlockMock
-        ).toHaveBeenCalledWith(`${sdkCommand} --version`, [
-            'ignore',
-            'pipe',
-            'pipe'
-        ]);
+        expect(myGenericVersionsCommandBlockMock).toHaveBeenCalledWith(
+            `${sdkCommand} --version`
+        );
     });
 
     test('Should attempt to look for android sdk tools (sdkmanager)', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myGenericVersionsCommandBlockMock
         );
         await AndroidSDKUtils.fetchAndroidCmdLineToolsLocation();
-        expect(
-            myGenericVersionsCommandBlockMock
-        ).toHaveBeenCalledWith(`${sdkCommand} --version`, [
-            'ignore',
-            'pipe',
-            'ignore'
-        ]);
+        expect(myGenericVersionsCommandBlockMock).toHaveBeenCalledWith(
+            `${sdkCommand} --version`
+        );
     });
 
     test('Should attempt to look for android sdk tools (sdkmanager)', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myGenericVersionsCommandBlockMockThrows
         );
         AndroidSDKUtils.fetchAndroidCmdLineToolsLocation().catch((error) => {
@@ -118,7 +121,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to look for android sdk platform tools', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myGenericVersionsCommandBlockMock
         );
         await AndroidSDKUtils.fetchAndroidSDKPlatformToolsLocation();
@@ -128,7 +131,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to look for android sdk platform tools', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myGenericVersionsCommandBlockMockThrows
         );
         AndroidSDKUtils.fetchAndroidSDKPlatformToolsLocation().catch(
@@ -139,7 +142,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to invoke the sdkmanager for installed packages', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         await AndroidSDKUtils.fetchInstalledPackages();
@@ -147,7 +150,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to invoke the sdkmanager and get installed packages', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         const packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -158,7 +161,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to invoke the sdkmanager and retrieve an empty list for a bad sdkmanager list', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             badBlockMock
         );
         const packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -170,7 +173,7 @@ describe('Android utils', () => {
     });
 
     test('Should establish cache on first call', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         const packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -178,7 +181,7 @@ describe('Android utils', () => {
     });
 
     test('Should utilize cache for subsequent calls', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         let packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -188,7 +191,7 @@ describe('Android utils', () => {
     });
 
     test('Should rebuild cache after clear in subsequent calls', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         let packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -199,7 +202,7 @@ describe('Android utils', () => {
     });
 
     test('Should rebuild cache after clear in subsequent calls', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         let packages = await AndroidSDKUtils.fetchInstalledPackages();
@@ -210,7 +213,7 @@ describe('Android utils', () => {
     });
 
     test('Should Find a preferred Android package', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         const apiPackage = await AndroidSDKUtils.findRequiredAndroidAPIPackage();
@@ -220,7 +223,7 @@ describe('Android utils', () => {
     });
 
     test('Should not find a preferred Android package', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             badBlockMock
         );
         AndroidSDKUtils.findRequiredAndroidAPIPackage().catch((error) => {
@@ -229,7 +232,7 @@ describe('Android utils', () => {
     });
 
     test('Should Find a preferred Android emulator package', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             myCommandBlockMock
         );
         const apiPackage = await AndroidSDKUtils.findRequiredEmulatorImages();
@@ -239,7 +242,7 @@ describe('Android utils', () => {
     });
 
     test('Should not find a preferred Android build tools package', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             badBlockMock
         );
         AndroidSDKUtils.findRequiredEmulatorImages().catch((error) => {
@@ -338,7 +341,7 @@ describe('Android utils', () => {
     });
 
     test('Should attempt to launch url and resolve.', async () => {
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             launchCommandMock
         );
         const url = 'mock.url';
@@ -374,11 +377,15 @@ describe('Android utils', () => {
             ` --es "${PreviewUtils.PROJECT_DIR_ARG_PREFIX}" "${projectDir}"` +
             ` --es "arg1" "val1" --es "arg2" "val2"`;
 
-        const mockCmd = jest.fn((): string => {
-            return `${targetApp}/.MainActivity`;
-        });
+        const mockCmd = jest.fn(
+            (): Promise<{ stdout: string; stderr: string }> =>
+                Promise.resolve({
+                    stderr: '',
+                    stdout: `${targetApp}/.MainActivity`
+                })
+        );
 
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             mockCmd
         );
 
@@ -449,11 +456,15 @@ describe('Android utils', () => {
             ` --es "${PreviewUtils.PROJECT_DIR_ARG_PREFIX}" "${projectDir}"` +
             ` --es "arg1" "val1" --es "arg2" "val2"`;
 
-        const mockCmd = jest.fn((): string => {
-            return `${targetApp}/.MainActivity`;
-        });
+        const mockCmd = jest.fn(
+            (): Promise<{ stdout: string; stderr: string }> =>
+                Promise.resolve({
+                    stderr: '',
+                    stdout: `${targetApp}/.MainActivity`
+                })
+        );
 
-        jest.spyOn(CommonUtils, 'executeCommandSync').mockImplementation(
+        jest.spyOn(CommonUtils, 'executeCommandAsync').mockImplementation(
             mockCmd
         );
 

--- a/src/common/__tests__/IOSUtils.test.ts
+++ b/src/common/__tests__/IOSUtils.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+// tslint:disable: no-unused-expression
 import { ActionBase } from 'cli-ux';
 import 'jest-chain';
 import 'jest-extended';
@@ -135,9 +136,8 @@ describe('IOS utils tests', () => {
             launchCommandThrowsAlreadryBootedMock
         );
         const udid = 'MOCKUDID';
-        return IOSUtils.bootDevice(udid).then((result) =>
-            expect(result).toBeTruthy()
-        );
+        const aPromise = IOSUtils.bootDevice(udid);
+        expect(aPromise).resolves;
     });
 
     test('Should wait for the device to boot', async () => {
@@ -145,9 +145,8 @@ describe('IOS utils tests', () => {
             launchCommandMock
         );
         const udid = 'MOCKUDID';
-        return IOSUtils.waitUntilDeviceIsReady(udid).then((result) =>
-            expect(result).toBeTruthy()
-        );
+        const aPromise = IOSUtils.waitUntilDeviceIsReady(udid);
+        expect(aPromise).resolves;
     });
 
     test('Should wait for the device to boot and fail if error is encountered', async () => {


### PR DESCRIPTION
We currently have many places in our repo where we are using anti async patterns:

- Functions that are async but not marked with `async` keyword
- Functions that are marked as async but are called in sync manner without calling `await()` on them
- Not taking advantage of Promise-chaining when having calls to multiple async function one after the other

This PR is to clean up all of these issues.