### PR TITLE
Support --apilevel flag for Device Create

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,7 @@
             "type": "node",
             "request": "launch",
             "name": "iOS - Preview",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:lwc:preview",
@@ -20,6 +21,7 @@
             "type": "node",
             "request": "launch",
             "name": "Android - Preview",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:lwc:preview",
@@ -35,6 +37,7 @@
             "type": "node",
             "request": "launch",
             "name": "iOS - Setup",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:setup",
@@ -46,6 +49,7 @@
             "type": "node",
             "request": "launch",
             "name": "Android - Setup",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:setup",
@@ -57,6 +61,7 @@
             "type": "node",
             "request": "launch",
             "name": "iOS - Device List",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:device:list",
@@ -68,6 +73,7 @@
             "type": "node",
             "request": "launch",
             "name": "Android - Device List",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:device:list",
@@ -79,6 +85,7 @@
             "type": "node",
             "request": "launch",
             "name": "iOS - Device Create",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:device:create",
@@ -94,6 +101,7 @@
             "type": "node",
             "request": "launch",
             "name": "Android - Device Create",
+            "console": "integratedTerminal",
             "program": "${workspaceFolder}/bin/run",
             "args": [
                 "force:lightning:local:device:create",

--- a/messages/device-create.json
+++ b/messages/device-create.json
@@ -1,6 +1,7 @@
 {
     "commandDescription": "Create a virtual mobile device",
     "platformFlagDescription": "Specify platform ('iOS' or 'Android').",
+    "apiLevelFlagDescription": "Optionally specify Android API level. Defaults to the latest API level available.",
     "deviceNameFlagDescription": "Virtual device name.",
     "deviceTypeFlagDescription": "Virtual device type.",
     "error:invalidPlatformFlagsDescription": "Invalid input value for platform.",

--- a/messages/device-create.json
+++ b/messages/device-create.json
@@ -1,7 +1,7 @@
 {
     "commandDescription": "Create a virtual mobile device",
     "platformFlagDescription": "Specify platform ('iOS' or 'Android').",
-    "apiLevelFlagDescription": "Optionally specify Android API level. Defaults to the latest API level available.",
+    "apiLevelFlagDescription": "Specify Android API level. Defaults to the latest API level installed.",
     "deviceNameFlagDescription": "Virtual device name.",
     "deviceTypeFlagDescription": "Virtual device type.",
     "error:invalidPlatformFlagsDescription": "Invalid input value for platform.",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@oclif/config": "^1.17.0",
     "@salesforce/command": "^3.1.0",
     "@salesforce/core": "^2.18.0",
-    "@salesforce/lwc-dev-mobile-core": "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.2.0-beta1/salesforce-lwc-dev-mobile-core-1.2.0.tgz",
+    "@salesforce/lwc-dev-mobile-core": "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.3.0-beta1/salesforce-lwc-dev-mobile-core-1.3.0.tgz",
     "chalk": "^4.1.0",
     "cli-ux": "^5.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@oclif/config": "^1.17.0",
     "@salesforce/command": "^3.1.0",
     "@salesforce/core": "^2.18.0",
-    "@salesforce/lwc-dev-mobile-core": "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.1.0-beta1/salesforce-lwc-dev-mobile-core-1.1.0.tgz",
+    "@salesforce/lwc-dev-mobile-core": "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.2.0-beta1/salesforce-lwc-dev-mobile-core-1.2.0.tgz",
     "chalk": "^4.1.0",
     "cli-ux": "^5.5.1"
   },

--- a/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
@@ -72,7 +72,7 @@ describe('Create Tests', () => {
         ).mockImplementation(createNewVirtualDeviceMock);
 
         const create = makeCreate(deviceName, androidDeviceType, 'android');
-        await create.run();
+        await create.run(true);
         expect(createNewVirtualDeviceMock).toHaveBeenCalledWith(
             deviceName,
             androidImage,
@@ -97,7 +97,7 @@ describe('Create Tests', () => {
         );
 
         const create = makeCreate(deviceName, iOSDeviceType, 'ios');
-        await create.run();
+        await create.run(true);
         expect(createNewDeviceMock).toHaveBeenCalledWith(
             deviceName,
             iOSDeviceType,
@@ -117,7 +117,7 @@ describe('Create Tests', () => {
             Promise.resolve()
         );
         const create = makeCreate(deviceName, androidDeviceType, 'android');
-        await create.run();
+        await create.run(true);
         expect(loggerSpy).toHaveBeenCalled();
     });
 

--- a/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
@@ -7,12 +7,12 @@
 
 import * as Config from '@oclif/config';
 import { Logger } from '@salesforce/core';
-import { Setup } from '@salesforce/lwc-dev-mobile-core/lib/cli/commands/force/lightning/local/setup';
 import { AndroidPackage } from '@salesforce/lwc-dev-mobile-core/lib/common/AndroidTypes';
 import { AndroidSDKUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/AndroidUtils';
 import { CommonUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/CommonUtils';
 import { Version } from '@salesforce/lwc-dev-mobile-core/lib/common/Common';
 import { IOSUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/IOSUtils';
+import { BaseSetup } from '@salesforce/lwc-dev-mobile-core/lib/common/Requirements';
 import { Create } from '../create';
 
 const passedSetupMock = jest.fn(() => {
@@ -27,37 +27,31 @@ const androidApi = 'android-29';
 const androidImage = 'google_apis';
 const androidABI = 'x86_64';
 
-describe('List Tests', () => {
-    const logger = new Logger('test-create');
-    let create: Create;
+const findEmulatorImagesMock = jest.fn(() => {
+    return Promise.resolve(
+        new AndroidPackage(
+            `${androidApi};${androidImage};${androidABI}`,
+            new Version(29, 0, 0),
+            'Google APIs Intel x86 Atom_64 System Image',
+            `system-images/${androidApi}/${androidImage}/${androidABI}/`
+        )
+    );
+});
 
+describe('Create Tests', () => {
     beforeEach(() => {
         // tslint:disable-next-line: no-empty
         jest.spyOn(CommonUtils, 'startCliAction').mockImplementation(() => {});
-
-        create = new Create(
-            [],
-            new Config.Config(({} as any) as Config.Options)
+        jest.spyOn(BaseSetup.prototype, 'executeSetup').mockImplementation(
+            passedSetupMock
         );
+    });
 
-        setupLogger();
-
-        jest.spyOn(Setup.prototype, 'run').mockImplementation(passedSetupMock);
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     test('Checks that launch for target platform for Android is invoked', async () => {
-        setupFlags('android', deviceName, androidDeviceType);
-
-        const findEmulatorImagesMock = jest.fn(() => {
-            return Promise.resolve(
-                new AndroidPackage(
-                    `${androidApi};${androidImage};${androidABI}`,
-                    new Version(29, 0, 0),
-                    'Google APIs Intel x86 Atom_64 System Image',
-                    `system-images/${androidApi}/${androidImage}/${androidABI}/`
-                )
-            );
-        });
         const nextAdbPortMock = jest.fn(() => {
             return Promise.resolve(0);
         });
@@ -68,6 +62,7 @@ describe('List Tests', () => {
             AndroidSDKUtils,
             'findRequiredEmulatorImages'
         ).mockImplementation(findEmulatorImagesMock);
+
         jest.spyOn(AndroidSDKUtils, 'getNextAndroidAdbPort').mockImplementation(
             nextAdbPortMock
         );
@@ -76,6 +71,7 @@ describe('List Tests', () => {
             'createNewVirtualDevice'
         ).mockImplementation(createNewVirtualDeviceMock);
 
+        const create = makeCreate(deviceName, androidDeviceType, 'android');
         await create.run();
         expect(createNewVirtualDeviceMock).toHaveBeenCalledWith(
             deviceName,
@@ -87,8 +83,6 @@ describe('List Tests', () => {
     });
 
     test('Checks that launch for target platform for iOS is invoked', async () => {
-        setupFlags('iOS', deviceName, iOSDeviceType);
-
         const getSupportedRuntimesMock = jest.fn(() => {
             return Promise.resolve(iOSSupportedRuntimes);
         });
@@ -102,6 +96,7 @@ describe('List Tests', () => {
             createNewDeviceMock
         );
 
+        const create = makeCreate(deviceName, iOSDeviceType, 'ios');
         await create.run();
         expect(createNewDeviceMock).toHaveBeenCalledWith(
             deviceName,
@@ -111,8 +106,17 @@ describe('List Tests', () => {
     });
 
     test('Logger must be initialized and invoked', async () => {
-        setupFlags('android', deviceName, androidDeviceType);
+        const logger = new Logger('test-logger');
         const loggerSpy = jest.spyOn(logger, 'info');
+        jest.spyOn(Logger, 'child').mockReturnValue(Promise.resolve(logger));
+        jest.spyOn(
+            AndroidSDKUtils,
+            'findRequiredEmulatorImages'
+        ).mockImplementation(findEmulatorImagesMock);
+        jest.spyOn(AndroidSDKUtils, 'createNewVirtualDevice').mockReturnValue(
+            Promise.resolve()
+        );
+        const create = makeCreate(deviceName, androidDeviceType, 'android');
         await create.run();
         expect(loggerSpy).toHaveBeenCalled();
     });
@@ -122,25 +126,11 @@ describe('List Tests', () => {
         expect(Create.description !== null).toBeTruthy();
     });
 
-    function setupFlags(platformFlag: string, name: string, type: string) {
-        Object.defineProperty(create, 'flags', {
-            get: () => {
-                return {
-                    devicename: name,
-                    devicetype: type,
-                    platform: platformFlag
-                };
-            }
-        });
-    }
-
-    function setupLogger() {
-        Object.defineProperty(create, 'logger', {
-            configurable: true,
-            enumerable: false,
-            get: () => {
-                return logger;
-            }
-        });
+    function makeCreate(name: string, type: string, platform: string): Create {
+        const create = new Create(
+            ['-n', name, '-d', type, '-p', platform],
+            new Config.Config(({} as any) as Config.Options)
+        );
+        return create;
     }
 });

--- a/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
@@ -29,32 +29,31 @@ const passedSetupMock = jest.fn(() => {
 });
 
 describe('List Tests', () => {
-    const logger = new Logger('test-list');
-    let list: List;
-
     beforeEach(() => {
-        list = new List([], new Config.Config(({} as any) as Config.Options));
-        list.iOSDeviceList = iOSListCommandBlockMock;
-        list.androidDeviceList = androidListCommandBlockMock;
-        setupLogger();
         jest.spyOn(Setup.prototype, 'run').mockImplementation(passedSetupMock);
     });
 
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
     test('Checks that launch for target platform for Android is invoked', async () => {
-        setupPlatformFlag('android');
+        const list = makeList('android');
         await list.run();
         expect(androidListCommandBlockMock).toHaveBeenCalled();
     });
 
     test('Checks that launch for target platform for iOS is invoked', async () => {
-        setupPlatformFlag('iOS');
+        const list = makeList('ios');
         await list.run();
         expect(iOSListCommandBlockMock).toHaveBeenCalled();
     });
 
     test('Logger must be initialized and invoked', async () => {
-        setupPlatformFlag('android');
+        const logger = new Logger('test-logger');
         const loggerSpy = jest.spyOn(logger, 'info');
+        jest.spyOn(Logger, 'child').mockReturnValue(Promise.resolve(logger));
+        const list = makeList('android');
         await list.run();
         expect(loggerSpy).toHaveBeenCalled();
     });
@@ -64,23 +63,13 @@ describe('List Tests', () => {
         expect(List.description !== null).toBeTruthy();
     });
 
-    function setupPlatformFlag(platformFlag: string) {
-        Object.defineProperty(list, 'flags', {
-            get: () => {
-                return {
-                    platform: platformFlag
-                };
-            }
-        });
-    }
-
-    function setupLogger() {
-        Object.defineProperty(list, 'logger', {
-            configurable: true,
-            enumerable: false,
-            get: () => {
-                return logger;
-            }
-        });
+    function makeList(platform: string): List {
+        const list = new List(
+            ['-p', platform],
+            new Config.Config(({} as any) as Config.Options)
+        );
+        list.iOSDeviceList = iOSListCommandBlockMock;
+        list.androidDeviceList = androidListCommandBlockMock;
+        return list;
     }
 });

--- a/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
@@ -39,13 +39,13 @@ describe('List Tests', () => {
 
     test('Checks that launch for target platform for Android is invoked', async () => {
         const list = makeList('android');
-        await list.run();
+        await list.run(true);
         expect(androidListCommandBlockMock).toHaveBeenCalled();
     });
 
     test('Checks that launch for target platform for iOS is invoked', async () => {
         const list = makeList('ios');
-        await list.run();
+        await list.run(true);
         expect(iOSListCommandBlockMock).toHaveBeenCalled();
     });
 
@@ -54,7 +54,7 @@ describe('List Tests', () => {
         const loggerSpy = jest.spyOn(logger, 'info');
         jest.spyOn(Logger, 'child').mockReturnValue(Promise.resolve(logger));
         const list = makeList('android');
-        await list.run();
+        await list.run(true);
         expect(loggerSpy).toHaveBeenCalled();
     });
 

--- a/src/cli/commands/force/lightning/local/device/create.ts
+++ b/src/cli/commands/force/lightning/local/device/create.ts
@@ -61,21 +61,23 @@ export class Create extends Setup {
     public deviceName: string = '';
     public deviceType: string = '';
 
-    public async run(): Promise<any> {
-        return this.init() // ensure init first
-            .then(() => {
-                this.logger.info(
-                    `Device Create command invoked for ${this.flags.platform}`
-                );
+    public async run(direct: boolean = false): Promise<any> {
+        if (direct) {
+            await this.init(); // ensure init first
+        }
 
-                const extraReqs: Requirement[] = [
-                    new DeviceNameAvailableRequirement(this, this.logger),
-                    new ValidDeviceTypeRequirement(this, this.logger)
-                ];
-                this.addAdditionalRequirements(extraReqs);
+        this.logger.info(
+            `Device Create command invoked for ${this.flags.platform}`
+        );
 
-                return super.run(); // validate input parameters + setup requirements
-            })
+        const extraReqs: Requirement[] = [
+            new DeviceNameAvailableRequirement(this, this.logger),
+            new ValidDeviceTypeRequirement(this, this.logger)
+        ];
+        this.addAdditionalRequirements(extraReqs);
+
+        return super
+            .run(direct) // validate input parameters + setup requirements
             .then(() => {
                 // execute the create command
                 this.logger.info(
@@ -152,7 +154,7 @@ export class Create extends Setup {
 
         return super
             .init()
-            .then(() => Logger.child('mobile:device:create', {}))
+            .then(() => Logger.child('force:lightning:local:device:create', {}))
             .then((logger) => {
                 this.logger = logger;
                 return Promise.resolve();

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -48,14 +48,16 @@ export class List extends Setup {
         PerformanceMarkers.FETCH_DEVICES_MARKER_KEY
     )!;
 
-    public async run(): Promise<any> {
-        return this.init() // ensure init first
-            .then(() => {
-                this.logger.info(
-                    `Device List command invoked for ${this.flags.platform}`
-                );
-                return this.validateInputParameters(); // validate input
-            })
+    public async run(direct: boolean = false): Promise<any> {
+        if (direct) {
+            await this.init(); // ensure init first
+        }
+
+        this.logger.info(
+            `Device List command invoked for ${this.flags.platform}`
+        );
+
+        return this.validateInputParameters() // validate input
             .then(() =>
                 CommandLineUtils.platformFlagIsIOS(this.flags.platform)
                     ? this.iOSDeviceList()
@@ -97,7 +99,7 @@ export class List extends Setup {
 
         return super
             .init()
-            .then(() => Logger.child('mobile:device:list', {}))
+            .then(() => Logger.child('force:lightning:local:device:list', {}))
             .then((logger) => {
                 this.logger = logger;
                 return Promise.resolve();

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -5,15 +5,13 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 
-import { flags, FlagsConfig, SfdxCommand } from '@salesforce/command';
-import { Logger, Messages, SfdxError } from '@salesforce/core';
-import { AndroidVirtualDevice } from '@salesforce/lwc-dev-mobile-core/lib/common/AndroidTypes';
+import { flags, FlagsConfig } from '@salesforce/command';
+import { Logger, Messages } from '@salesforce/core';
+import { Setup } from '@salesforce/lwc-dev-mobile-core/lib/cli/commands/force/lightning/local/setup';
 import { AndroidSDKUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/AndroidUtils';
 import { CommandLineUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/Common';
 import { CommonUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/CommonUtils';
-import { IOSSimulatorDevice } from '@salesforce/lwc-dev-mobile-core/lib/common/IOSTypes';
 import { IOSUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/IOSUtils';
-import { LoggerSetup } from '@salesforce/lwc-dev-mobile-core/lib/common/LoggerSetup';
 import { PerformanceMarkers } from '@salesforce/lwc-dev-mobile-core/lib/common/PerformanceMarkers';
 import chalk from 'chalk';
 import cli from 'cli-ux';
@@ -29,7 +27,7 @@ const messages = Messages.loadMessages(
     'device-list'
 );
 
-export class List extends SfdxCommand {
+export class List extends Setup {
     public static description = messages.getMessage('commandDescription');
 
     public static readonly flagsConfig: FlagsConfig = {
@@ -51,25 +49,21 @@ export class List extends SfdxCommand {
     )!;
 
     public async run(): Promise<any> {
-        const platform = this.flags.platform;
-        this.logger.info(`Device List command invoked for ${platform}`);
-
-        if (!CommandLineUtils.platformFlagIsValid(platform)) {
-            return Promise.reject(
-                new SfdxError(
-                    messages.getMessage('error:invalidInputFlagsDescription'),
-                    'lwc-dev-mobile',
-                    this.examples
-                )
+        return this.init() // ensure init first
+            .then(() => {
+                this.logger.info(
+                    `Device List command invoked for ${this.flags.platform}`
+                );
+                return this.validateInputParameters(); // validate input
+            })
+            .then(() =>
+                CommandLineUtils.platformFlagIsIOS(this.flags.platform)
+                    ? this.iOSDeviceList()
+                    : this.androidDeviceList()
             );
-        }
-
-        return CommandLineUtils.platformFlagIsIOS(platform)
-            ? this.iOSDeviceList()
-            : this.androidDeviceList();
     }
 
-    public async iOSDeviceList(): Promise<IOSSimulatorDevice[]> {
+    public async iOSDeviceList(): Promise<any> {
         CommonUtils.startCliAction(
             'Device List',
             'Generating list of supported simulators'
@@ -82,7 +76,7 @@ export class List extends SfdxCommand {
         return Promise.resolve(result);
     }
 
-    public async androidDeviceList(): Promise<AndroidVirtualDevice[]> {
+    public async androidDeviceList(): Promise<any> {
         CommonUtils.startCliAction(
             'Device List',
             'Generating list of supported simulators'
@@ -96,10 +90,18 @@ export class List extends SfdxCommand {
     }
 
     protected async init(): Promise<void> {
-        await super.init();
-        const logger = await Logger.child('mobile:device:list', {});
-        this.logger = logger;
-        await LoggerSetup.initializePluginLoggers();
+        if (this.logger) {
+            // already initialized
+            return Promise.resolve();
+        }
+
+        return super
+            .init()
+            .then(() => Logger.child('mobile:device:list', {}))
+            .then((logger) => {
+                this.logger = logger;
+                return Promise.resolve();
+            });
     }
 
     private showDeviceList(list: any[]) {

--- a/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
+++ b/src/cli/commands/force/lightning/lwc/__tests__/preview.test.ts
@@ -36,7 +36,7 @@ describe('Preview Tests', () => {
         });
         const preview = makePreview('compname', 'android', 'sfdxdebug');
         preview.validateInputParameters = compPathCallValidationlMock;
-        await preview.run();
+        await preview.run(true);
         expect(compPathCallValidationlMock).toHaveBeenCalled();
     });
 
@@ -44,7 +44,7 @@ describe('Preview Tests', () => {
         const targetAndroidCallMock = jest.fn(() => Promise.resolve());
         const preview = makePreview('compname', 'android', 'sfdxdebug');
         preview.launchPreview = targetAndroidCallMock;
-        await preview.run();
+        await preview.run(true);
         expect(targetAndroidCallMock).toHaveBeenCalled();
     });
 
@@ -52,13 +52,13 @@ describe('Preview Tests', () => {
         const preview = makePreview('compname', 'ios', 'sfdxdebug');
         const targetIOSCallMock = jest.fn(() => Promise.resolve());
         preview.launchPreview = targetIOSCallMock;
-        await preview.run();
+        await preview.run(true);
         expect(targetIOSCallMock).toHaveBeenCalled();
     });
 
     test('Checks that setup is invoked', async () => {
         const preview = makePreview('compname', 'android', 'sfdxdebug');
-        await preview.run();
+        await preview.run(true);
         expect(passedSetupMock);
     });
 
@@ -67,7 +67,7 @@ describe('Preview Tests', () => {
         jest.spyOn(Setup.prototype, 'run').mockImplementation(failedSetupMock);
 
         try {
-            await preview.run();
+            await preview.run(true);
         } catch (error) {
             expect(error instanceof SfdxError).toBeTruthy();
         }
@@ -137,7 +137,7 @@ describe('Preview Tests', () => {
         const loggerSpy = jest.spyOn(logger, 'info');
         jest.spyOn(Logger, 'child').mockReturnValue(Promise.resolve(logger));
         const preview = makePreview('compname', 'android', 'sfdxdebug');
-        await preview.run();
+        await preview.run(true);
         expect(loggerSpy).toHaveBeenCalled();
     });
 

--- a/src/cli/commands/force/lightning/lwc/preview.ts
+++ b/src/cli/commands/force/lightning/lwc/preview.ts
@@ -101,14 +101,14 @@ export class Preview extends Setup {
         | AndroidAppPreviewConfig
         | undefined;
 
-    public async run(): Promise<any> {
-        return this.init() // ensure init first
-            .then(() => {
-                this.logger.info(
-                    `Preview command invoked for ${this.flags.platform}`
-                );
-                return this.validateInputParameters(); // validate input
-            })
+    public async run(direct: boolean = false): Promise<any> {
+        if (direct) {
+            await this.init(); // ensure init first
+        }
+
+        this.logger.info(`Preview command invoked for ${this.flags.platform}`);
+
+        return this.validateInputParameters() // validate input
             .then(() => {
                 if (
                     PreviewUtils.useLwcServerForPreviewing(
@@ -121,7 +121,7 @@ export class Preview extends Setup {
                     ];
                     this.addAdditionalRequirements(extraReqs);
                 }
-                return super.run(); // verify requirements
+                return super.run(direct); // verify requirements
             })
             .then(() => {
                 // then launch the preview if all validations have passed
@@ -340,7 +340,7 @@ export class Preview extends Setup {
 
         return super
             .init()
-            .then(() => Logger.child('mobile:preview', {}))
+            .then(() => Logger.child('force:lightning:lwc:preview', {}))
             .then((logger) => {
                 this.logger = logger;
                 return Promise.resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,9 +705,9 @@
     "@salesforce/ts-types" "^1.5.0"
     tslib "^1.10.0"
 
-"@salesforce/lwc-dev-mobile-core@https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.2.0-beta1/salesforce-lwc-dev-mobile-core-1.2.0.tgz":
-  version "1.2.0"
-  resolved "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.2.0-beta1/salesforce-lwc-dev-mobile-core-1.2.0.tgz#694d89b3b038433c792b47ee8fec42329149f4c0"
+"@salesforce/lwc-dev-mobile-core@https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.3.0-beta1/salesforce-lwc-dev-mobile-core-1.3.0.tgz":
+  version "1.3.0"
+  resolved "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.3.0-beta1/salesforce-lwc-dev-mobile-core-1.3.0.tgz#ec5747d2ae3569b87491bd2f1f1e1f68c090d9ce"
   dependencies:
     "@oclif/config" "^1.17.0"
     "@salesforce/command" "^3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,9 +705,9 @@
     "@salesforce/ts-types" "^1.5.0"
     tslib "^1.10.0"
 
-"@salesforce/lwc-dev-mobile-core@https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.1.0-beta1/salesforce-lwc-dev-mobile-core-1.1.0.tgz":
-  version "1.1.0"
-  resolved "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.1.0-beta1/salesforce-lwc-dev-mobile-core-1.1.0.tgz#01babfa16cfcf6d33f2d30919678aaec26a315cd"
+"@salesforce/lwc-dev-mobile-core@https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.2.0-beta1/salesforce-lwc-dev-mobile-core-1.2.0.tgz":
+  version "1.2.0"
+  resolved "https://github.com/forcedotcom/lwc-dev-mobile/releases/download/core-dep-1.2.0-beta1/salesforce-lwc-dev-mobile-core-1.2.0.tgz#694d89b3b038433c792b47ee8fec42329149f4c0"
   dependencies:
     "@oclif/config" "^1.17.0"
     "@salesforce/command" "^3.1.0"


### PR DESCRIPTION
Add support for the optional --apilevel flag so users can target a specific API version when creating AVDs.