### PR TITLE
Add Device:Start command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -114,6 +114,35 @@
             ]
         },
         {
+            "type": "node",
+            "request": "launch",
+            "name": "iOS - Device Start",
+            "console": "integratedTerminal",
+            "program": "${workspaceFolder}/bin/run",
+            "args": [
+                "force:lightning:local:device:start",
+                "-p",
+                "iOS",
+                "-t",
+                "sfdxdebug"
+            ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Android - Device Start",
+            "console": "integratedTerminal",
+            "program": "${workspaceFolder}/bin/run",
+            "args": [
+                "force:lightning:local:device:start",
+                "-p",
+                "android",
+                "-t",
+                "sfdxdebug",
+                "-w"
+            ]
+        },
+        {
             "name": "ts-node",
             "type": "node",
             "request": "launch",

--- a/messages/device-start.json
+++ b/messages/device-start.json
@@ -1,0 +1,8 @@
+{
+    "commandDescription": "Start a virtual mobile device",
+    "platformFlagDescription": "Specify platform ('iOS' or 'Android').",
+    "targetFlagDescription": "Specify target virtual device name.",
+    "writablesystemFlagDescription": "Specify whether a virtual device should be launched with writable system access. Applicable to Android devices only. Defaults to false.",
+    "error:invalidTargetFlagsDescription": "Invalid or missing value for target device name.",
+    "error:targetDoesNotExistDescription": "Target device does not exist: %s."
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile",
   "description": "Salesforce CLI plugin for mobile extensions to Local Development",
-  "version": "1.1.1-beta3",
+  "version": "1.1.1-beta4",
   "author": {
     "name": "Raj Rao",
     "email": "rao.r@salesforce.com",
@@ -29,7 +29,7 @@
     "@oclif/config": "^1.17.0",
     "@salesforce/command": "^3.1.0",
     "@salesforce/core": "^2.18.0",
-    "@salesforce/lwc-dev-mobile-core": "^1.0.0-beta3",
+    "@salesforce/lwc-dev-mobile-core": "^1.0.0-beta4",
     "chalk": "^4.1.0",
     "cli-ux": "^5.5.1"
   },

--- a/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/create.test.ts
@@ -63,9 +63,6 @@ describe('Create Tests', () => {
             'fetchSupportedEmulatorImagePackage'
         ).mockImplementation(findEmulatorImagesMock);
 
-        jest.spyOn(AndroidUtils, 'getNextAndroidAdbPort').mockImplementation(
-            nextAdbPortMock
-        );
         jest.spyOn(AndroidUtils, 'createNewVirtualDevice').mockImplementation(
             createNewVirtualDeviceMock
         );

--- a/src/cli/commands/force/lightning/local/device/__tests__/start.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/start.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import * as Config from '@oclif/config';
+import { Logger } from '@salesforce/core';
+import { AndroidUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/AndroidUtils';
+import { CommonUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/CommonUtils';
+import { IOSSimulatorDevice } from '@salesforce/lwc-dev-mobile-core/lib/common/IOSTypes';
+import { IOSUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/IOSUtils';
+import { BaseSetup } from '@salesforce/lwc-dev-mobile-core/lib/common/Requirements';
+import { Start } from '../start';
+
+const targetName = 'MyDevice';
+const targetUDID = 'myUDID';
+const emulatorPort = 5572;
+const hasEmulatorMock = jest.fn(() => Promise.resolve(true));
+const getSimulatorMock = jest.fn(() =>
+    Promise.resolve(
+        new IOSSimulatorDevice(
+            targetName,
+            targetUDID,
+            'active',
+            'runtimeID',
+            true
+        )
+    )
+);
+const passedSetupMock = jest.fn(() => {
+    return Promise.resolve({ hasMetAllRequirements: true, tests: [] });
+});
+
+describe('Start Tests', () => {
+    beforeEach(() => {
+        // tslint:disable-next-line: no-empty
+        jest.spyOn(CommonUtils, 'startCliAction').mockImplementation(() => {});
+        jest.spyOn(BaseSetup.prototype, 'executeSetup').mockImplementation(
+            passedSetupMock
+        );
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('Checks that launch for target platform for Android is invoked', async () => {
+        const startEmulatorMock = jest.fn(() => {
+            return Promise.resolve(emulatorPort);
+        });
+
+        jest.spyOn(AndroidUtils, 'hasEmulator').mockImplementation(
+            hasEmulatorMock
+        );
+
+        jest.spyOn(AndroidUtils, 'startEmulator').mockImplementation(
+            startEmulatorMock
+        );
+
+        const start = makeStart('android', targetName, true);
+        await start.run(true);
+        expect(startEmulatorMock).toHaveBeenCalledWith(targetName, true, false);
+    });
+
+    test('Checks that launch for target platform for iOS is invoked', async () => {
+        const bootDeviceMock = jest.fn(() => Promise.resolve());
+        const launchSimulatorAppMock = jest.fn(() => Promise.resolve());
+
+        jest.spyOn(IOSUtils, 'getSimulator').mockImplementation(
+            getSimulatorMock
+        );
+
+        jest.spyOn(IOSUtils, 'bootDevice').mockImplementation(bootDeviceMock);
+
+        jest.spyOn(IOSUtils, 'launchSimulatorApp').mockImplementation(
+            launchSimulatorAppMock
+        );
+
+        const start = makeStart('iOS', targetName);
+        await start.run(true);
+        expect(bootDeviceMock).toHaveBeenCalledWith(targetUDID, false);
+    });
+
+    test('Logger must be initialized and invoked', async () => {
+        const logger = new Logger('test-logger');
+        const loggerSpy = jest.spyOn(logger, 'info');
+        jest.spyOn(Logger, 'child').mockReturnValue(Promise.resolve(logger));
+
+        const bootDeviceMock = jest.fn(() => Promise.resolve());
+        const launchSimulatorAppMock = jest.fn(() => Promise.resolve());
+
+        jest.spyOn(IOSUtils, 'getSimulator').mockImplementation(
+            getSimulatorMock
+        );
+
+        jest.spyOn(IOSUtils, 'bootDevice').mockImplementation(bootDeviceMock);
+
+        jest.spyOn(IOSUtils, 'launchSimulatorApp').mockImplementation(
+            launchSimulatorAppMock
+        );
+
+        const start = makeStart('iOS', targetName);
+        await start.run(true);
+        expect(loggerSpy).toHaveBeenCalled();
+    });
+
+    test('Messages folder should be loaded', async () => {
+        expect.assertions(1);
+        expect(Start.description !== null).toBeTruthy();
+    });
+
+    function makeStart(
+        platform: string,
+        target: string,
+        writable: boolean = false
+    ): Start {
+        const args = ['-p', platform, '-t', target];
+        if (writable) {
+            args.push('-w');
+        }
+        const start = new Start(
+            args,
+            new Config.Config(({} as any) as Config.Options)
+        );
+        return start;
+    }
+});

--- a/src/cli/commands/force/lightning/local/device/start.ts
+++ b/src/cli/commands/force/lightning/local/device/start.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { flags, FlagsConfig } from '@salesforce/command';
+import { Logger, Messages, SfdxError } from '@salesforce/core';
+import { Setup } from '@salesforce/lwc-dev-mobile-core/lib/cli/commands/force/lightning/local/setup';
+import { AndroidUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/AndroidUtils';
+import { CommandLineUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/Common';
+import { CommonUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/CommonUtils';
+import { IOSUtils } from '@salesforce/lwc-dev-mobile-core/lib/common/IOSUtils';
+import util from 'util';
+
+// Initialize Messages with the current plugin directory
+Messages.importMessagesDirectory(__dirname);
+
+// Load the specific messages for this file. Messages from @salesforce/command, @salesforce/core,
+// or any library that is using the messages framework can also be loaded this way.
+const messages = Messages.loadMessages(
+    '@salesforce/lwc-dev-mobile',
+    'device-start'
+);
+
+const LWC_DEV_MOBILE = 'lwc-dev-mobile';
+const DEVICE_START = 'Device Start';
+
+export class Start extends Setup {
+    public static description = messages.getMessage('commandDescription');
+
+    public static readonly flagsConfig: FlagsConfig = {
+        platform: flags.string({
+            char: 'p',
+            description: messages.getMessage('platformFlagDescription'),
+            required: true
+        }),
+        target: flags.string({
+            char: 't',
+            description: messages.getMessage('targetFlagDescription'),
+            required: true
+        }),
+        writablesystem: flags.boolean({
+            char: 'w',
+            description: messages.getMessage('writablesystemFlagDescription'),
+            required: false,
+            default: false
+        })
+    };
+
+    public examples = [
+        `sfdx force:lightning:local:device:start -p iOS -t MySimulator`,
+        `sfdx force:lightning:local:device:create -p Android -t MyEmulator -w`
+    ];
+
+    private platform = '';
+    private target = '';
+    private writableSystem = false;
+
+    public async run(direct: boolean = false): Promise<any> {
+        if (direct) {
+            await this.init(); // ensure init first
+        }
+
+        this.logger.info(
+            `Device Start command invoked for ${this.flags.platform}`
+        );
+
+        return super
+            .run(direct) // validate input parameters + setup requirements
+            .then(() => {
+                // execute the create command
+                this.logger.info(
+                    'Setup requirements met, continuing with Device Start'
+                );
+                return this.executeDeviceStart();
+            });
+    }
+
+    protected async validateInputParameters(): Promise<void> {
+        return super.validateInputParameters().then(() => {
+            const target = this.flags.target as string;
+            const writableSystem = this.flags.writablesystem as boolean;
+
+            // ensure that thetarget flag value is valid
+            if (target == null || target.trim() === '') {
+                return Promise.reject(
+                    new SfdxError(
+                        messages.getMessage(
+                            'error:invalidTargetFlagsDescription'
+                        ),
+                        LWC_DEV_MOBILE,
+                        this.examples
+                    )
+                );
+            }
+
+            this.platform = this.flags.platform;
+            this.target = target;
+            this.writableSystem = writableSystem;
+            return Promise.resolve();
+        });
+    }
+
+    protected async init(): Promise<void> {
+        if (this.logger) {
+            // already initialized
+            return Promise.resolve();
+        }
+
+        return super
+            .init()
+            .then(() => Logger.child('force:lightning:local:device:start', {}))
+            .then((logger) => {
+                this.logger = logger;
+                return Promise.resolve();
+            });
+    }
+
+    private async executeDeviceStart(): Promise<any> {
+        const isAndroid = CommandLineUtils.platformFlagIsAndroid(this.platform);
+        return isAndroid
+            ? this.executeAndroidDeviceStart()
+            : this.executeIOSDeviceStart();
+    }
+
+    private async executeAndroidDeviceStart(): Promise<void> {
+        return AndroidUtils.hasEmulator(this.target)
+            .then((hasEmulator) => {
+                if (!hasEmulator) {
+                    return Promise.reject(
+                        new SfdxError(
+                            util.format(
+                                messages.getMessage(
+                                    'error:targetDoesNotExistDescription'
+                                ),
+                                this.target
+                            ),
+                            LWC_DEV_MOBILE
+                        )
+                    );
+                } else {
+                    CommonUtils.startCliAction(
+                        DEVICE_START,
+                        `starting device ${this.target}`
+                    );
+                    return AndroidUtils.startEmulator(
+                        this.target,
+                        this.writableSystem,
+                        false
+                    );
+                }
+            })
+            .then((actualPort) => {
+                CommonUtils.stopCliAction(
+                    `device ${this.target} started on port ${actualPort}, writable system = ${this.writableSystem}`
+                );
+                return Promise.resolve();
+            });
+    }
+
+    private async executeIOSDeviceStart(): Promise<void> {
+        let simDeviceUDID = '';
+        return IOSUtils.getSimulator(this.target)
+            .then((simDevice) => {
+                if (simDevice === null) {
+                    return Promise.reject(
+                        new SfdxError(
+                            util.format(
+                                messages.getMessage(
+                                    'error:targetDoesNotExistDescription'
+                                ),
+                                this.target
+                            ),
+                            LWC_DEV_MOBILE
+                        )
+                    );
+                } else {
+                    simDeviceUDID = simDevice.udid;
+                    return Promise.resolve();
+                }
+            })
+            .then(() => {
+                CommonUtils.startCliAction(
+                    DEVICE_START,
+                    `starting device ${this.target} (${simDeviceUDID})`
+                );
+                return IOSUtils.bootDevice(simDeviceUDID, false);
+            })
+            .then(() => IOSUtils.launchSimulatorApp())
+            .then(() => {
+                CommonUtils.stopCliAction(
+                    `device ${this.target} (${simDeviceUDID}) started.`
+                );
+                return Promise.resolve();
+            });
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,10 +705,10 @@
     "@salesforce/ts-types" "^1.5.0"
     tslib "^1.10.0"
 
-"@salesforce/lwc-dev-mobile-core@^1.0.0-beta3":
-  version "1.0.0-beta3"
-  resolved "https://registry.yarnpkg.com/@salesforce/lwc-dev-mobile-core/-/lwc-dev-mobile-core-1.0.0-beta3.tgz#7af0789b544fd7f9adc4418c8eab4824d79c7a8b"
-  integrity sha512-UIJ+p8s4PhDVIddUbL1P16Cs9LKkgKSX4HCAVdgYsp8Ml4Vi4j2rqwVn1T4FS/YgXG+c4zKgKLS/dWnqupumhA==
+"@salesforce/lwc-dev-mobile-core@^1.0.0-beta4":
+  version "1.0.0-beta4"
+  resolved "https://registry.yarnpkg.com/@salesforce/lwc-dev-mobile-core/-/lwc-dev-mobile-core-1.0.0-beta4.tgz#9c695123a22962569889eab99aaaef571313a040"
+  integrity sha512-cUN6tMFtZ/jjuA5pfQyOa/A/k+uddhPvd7ziy7sW3S+Zkqkn/dKNmMhBjuTHSUr7Ob73/aw95/lUN2MdayT79w==
   dependencies:
     "@oclif/config" "^1.17.0"
     "@salesforce/command" "^3.1.0"


### PR DESCRIPTION
Add a new `device:start` command that would allow for launching a simulator/emulator. For Android the user would have the option of launching a device with writable system.