### PR TITLE
Consuming lwc-dev-mobile-core 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/lwc-dev-mobile",
   "description": "Salesforce CLI plugin for mobile extensions to Local Development",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "Raj Rao",
     "email": "rao.r@salesforce.com",
@@ -34,7 +34,7 @@
     "@oclif/config": "^1.18.2",
     "@salesforce/command": "^4.2.1",
     "@salesforce/core": "^2.31.1",
-    "@salesforce/lwc-dev-mobile-core": "1.3.0",
+    "@salesforce/lwc-dev-mobile-core": "^2.0.0",
     "chalk": "^4.1.2",
     "cli-ux": "^6.0.6"
   },

--- a/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
+++ b/src/cli/commands/force/lightning/local/device/__tests__/list.test.ts
@@ -52,7 +52,7 @@ const androidDevices: AndroidVirtualDevice[] = [
         'pixel-xl-path',
         'Google APIs',
         'Android 9',
-        Version.from('28')
+        Version.from('28')!
     ),
     new AndroidVirtualDevice(
         'Nexus_5X',
@@ -60,7 +60,7 @@ const androidDevices: AndroidVirtualDevice[] = [
         'nexus-5x-path',
         'Google APIs',
         'Android 10',
-        Version.from('29')
+        Version.from('29')!
     ),
     new AndroidVirtualDevice(
         'Pixel_4_XL',
@@ -68,7 +68,7 @@ const androidDevices: AndroidVirtualDevice[] = [
         'pixel-4-xl-path',
         'Google APIs',
         'Android 11',
-        Version.from('30')
+        Version.from('30')!
     )
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -771,10 +771,10 @@
     shx "^0.3.3"
     tslib "^2.2.0"
 
-"@salesforce/lwc-dev-mobile-core@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/lwc-dev-mobile-core/-/lwc-dev-mobile-core-1.3.0.tgz#eccba5a4edb68930cf9ed6d8635894d18b78e8f6"
-  integrity sha512-lvGH1wHcVCvP9ijI5V96HdY4GEbp+txQsVTGBcldDFfjgIQA3LZ3P/6sjG4wTASbYA8jnixwL+FUoUNSli+kwQ==
+"@salesforce/lwc-dev-mobile-core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@salesforce/lwc-dev-mobile-core/-/lwc-dev-mobile-core-2.0.0.tgz#8082ed685ff5a966f330c689872a95533b912003"
+  integrity sha512-+Q6CI6TqgJBWRhUjeZ5+IjF/jr0fr24SVFj2E3/RO8r1NH8n7IAPsBzl+KF+MTZzbXyAuB2m9KR8e9ZbotQv7A==
   dependencies:
     "@oclif/config" "^1.18.2"
     "@salesforce/command" "^4.2.1"


### PR DESCRIPTION
Does what it says on the tin: consuming the lwc-dev-mobile-core 2.0 changes, to account for `Version.from()` no longer throwing errors.