### PR TITLE
chore: migrate tests

### DIFF
--- a/src/cli/commands/force/lightning/local/device/create.ts
+++ b/src/cli/commands/force/lightning/local/device/create.ts
@@ -124,7 +124,14 @@ export class Create extends BaseCommand {
         const emuImage = preferredPack.platformEmulatorImage ?? 'default';
         const androidApi = preferredPack.platformAPI;
         const abi = preferredPack.abi;
-        return AndroidUtils.createNewVirtualDevice(this.deviceName, emuImage, androidApi, this.deviceType, abi, this.logger);
+        return AndroidUtils.createNewVirtualDevice(
+            this.deviceName,
+            emuImage,
+            androidApi,
+            this.deviceType,
+            abi,
+            this.logger
+        );
     }
 
     private async executeIOSDeviceCreate(): Promise<void> {
@@ -202,8 +209,8 @@ class ValidDeviceTypeRequirement implements Requirement {
         return match !== undefined
             ? Promise.resolve(util.format(this.fulfilledMessage, this.owner.deviceType))
             : Promise.reject(
-                util.format(this.unfulfilledMessage, this.owner.deviceType, supportedDeviceTypes.join(', '))
-            );
+                  util.format(this.unfulfilledMessage, this.owner.deviceType, supportedDeviceTypes.join(', '))
+              );
     }
 }
 

--- a/src/cli/commands/force/lightning/local/device/create.ts
+++ b/src/cli/commands/force/lightning/local/device/create.ts
@@ -87,9 +87,9 @@ export class Create extends BaseCommand {
                 const message = messages.getMessage('device.create.successStatus', [this.deviceName, this.deviceType]);
                 CommonUtils.stopCliAction(message);
             })
-            .catch((error) => {
+            .catch((error: Error) => {
                 CommonUtils.stopCliAction(messages.getMessage('device.create.failureStatus'));
-                this.logger.warn(`Device Create failed for ${this.platform}.`);
+                this.logger.warn(`Device Create failed for ${this.platform} - ${error.message}`);
                 return Promise.reject(error);
             });
     }
@@ -124,7 +124,7 @@ export class Create extends BaseCommand {
         const emuImage = preferredPack.platformEmulatorImage ?? 'default';
         const androidApi = preferredPack.platformAPI;
         const abi = preferredPack.abi;
-        return AndroidUtils.createNewVirtualDevice(this.deviceName, emuImage, androidApi, this.deviceType, abi);
+        return AndroidUtils.createNewVirtualDevice(this.deviceName, emuImage, androidApi, this.deviceType, abi, this.logger);
     }
 
     private async executeIOSDeviceCreate(): Promise<void> {
@@ -202,8 +202,8 @@ class ValidDeviceTypeRequirement implements Requirement {
         return match !== undefined
             ? Promise.resolve(util.format(this.fulfilledMessage, this.owner.deviceType))
             : Promise.reject(
-                  util.format(this.unfulfilledMessage, this.owner.deviceType, supportedDeviceTypes.join(', '))
-              );
+                util.format(this.unfulfilledMessage, this.owner.deviceType, supportedDeviceTypes.join(', '))
+            );
     }
 }
 

--- a/src/cli/commands/force/lightning/lwc/test/ui/mobile/configure.ts
+++ b/src/cli/commands/force/lightning/lwc/test/ui/mobile/configure.ts
@@ -175,8 +175,8 @@ export class Configure extends BaseCommand {
             .then(() => {
                 this.logger.info(`Config file created at ${this.output}`);
             })
-            .catch((error) => {
-                this.logger.warn(`Failed to created config file - ${error}`);
+            .catch((error: Error) => {
+                this.logger.warn(`Failed to created config file - ${error.message}`);
                 return Promise.reject(error);
             });
     }
@@ -236,19 +236,19 @@ export class Configure extends BaseCommand {
             capabilities: [
                 isAndroid
                     ? {
-                          'appium:platformName': 'Android',
-                          'appium:automationName': 'UiAutomator2',
-                          'appium:app': this.bundlePath,
-                          'appium:appActivity': this.appActivity,
-                          'appium:appPackage': this.appPackage,
-                          'appium:avd': device.name
-                      }
+                        'appium:platformName': 'Android',
+                        'appium:automationName': 'UiAutomator2',
+                        'appium:app': this.bundlePath,
+                        'appium:appActivity': this.appActivity,
+                        'appium:appPackage': this.appPackage,
+                        'appium:avd': device.name
+                    }
                     : {
-                          'appium:platformName': 'iOS',
-                          'appium:automationName': 'XCUITest',
-                          'appium:app': this.bundlePath,
-                          'appium:udid': (device as AppleDevice).id
-                      }
+                        'appium:platformName': 'iOS',
+                        'appium:automationName': 'XCUITest',
+                        'appium:app': this.bundlePath,
+                        'appium:udid': (device as AppleDevice).id
+                    }
             ],
             framework: this.testFramework,
             baseUrl: this.baseUrl

--- a/src/cli/commands/force/lightning/lwc/test/ui/mobile/configure.ts
+++ b/src/cli/commands/force/lightning/lwc/test/ui/mobile/configure.ts
@@ -236,19 +236,19 @@ export class Configure extends BaseCommand {
             capabilities: [
                 isAndroid
                     ? {
-                        'appium:platformName': 'Android',
-                        'appium:automationName': 'UiAutomator2',
-                        'appium:app': this.bundlePath,
-                        'appium:appActivity': this.appActivity,
-                        'appium:appPackage': this.appPackage,
-                        'appium:avd': device.name
-                    }
+                          'appium:platformName': 'Android',
+                          'appium:automationName': 'UiAutomator2',
+                          'appium:app': this.bundlePath,
+                          'appium:appActivity': this.appActivity,
+                          'appium:appPackage': this.appPackage,
+                          'appium:avd': device.name
+                      }
                     : {
-                        'appium:platformName': 'iOS',
-                        'appium:automationName': 'XCUITest',
-                        'appium:app': this.bundlePath,
-                        'appium:udid': (device as AppleDevice).id
-                    }
+                          'appium:platformName': 'iOS',
+                          'appium:automationName': 'XCUITest',
+                          'appium:app': this.bundlePath,
+                          'appium:udid': (device as AppleDevice).id
+                      }
             ],
             framework: this.testFramework,
             baseUrl: this.baseUrl

--- a/test/unit/cli/commands/force/lightning/local/device/create.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/create.test.ts
@@ -4,17 +4,25 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-import { Logger, Messages } from '@salesforce/core';
+
+import sinon from 'sinon';
+import { Logger } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
-import { AppleDeviceManager, IOSUtils, RequirementProcessor } from '@salesforce/lwc-dev-mobile-core';
+import { AndroidPackage, AndroidUtils, AppleDeviceManager, AppleRuntime, IOSUtils, RequirementProcessor, Version } from '@salesforce/lwc-dev-mobile-core';
 import { expect } from 'chai';
 import { Create } from '../../../../../../../../src/cli/commands/force/lightning/local/device/create.js';
 
-Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
-
-describe('Create Tests', () => {
+describe('Device Create Tests', () => {
     const $$ = new TestContext();
+
+    const deviceName = 'MyDeviceName';
+    const iOSDeviceType = 'iPhone-16';
+    const androidDeviceType = 'pixel_xl';
+    const androidApi = 'android-35';
+    const androidImage = 'google_apis';
+    const androidABI = 'x86_64';
+
     let executeSetupMock: sinon.SinonStub<any[], any>;
 
     beforeEach(() => {
@@ -24,6 +32,62 @@ describe('Create Tests', () => {
 
     afterEach(() => {
         $$.restore();
+    });
+
+    it('Creates new Android emulator', async () => {
+        const emulatorImagesMock = stubMethod($$.SANDBOX, AndroidUtils, 'fetchSupportedEmulatorImagePackage');
+        emulatorImagesMock.resolves(
+            new AndroidPackage(
+                `${androidApi};${androidImage};${androidABI}`,
+                new Version(35, 0, 0),
+                'Google APIs Intel x86 Atom_64 System Image',
+                `system-images/${androidApi}/${androidImage}/${androidABI}/`
+            )
+        )
+
+        const createAvdMock = stubMethod($$.SANDBOX, AndroidUtils, 'createNewVirtualDevice');
+        createAvdMock.resolves();
+
+        await Create.run(['-p', 'android', '-n', deviceName, '-d', androidDeviceType]);
+
+        expect(executeSetupMock.called).to.be.true;
+        expect(emulatorImagesMock.called).to.be.true;
+        expect(createAvdMock.calledWith(deviceName, androidImage, androidApi, androidDeviceType, androidABI, sinon.match.any)).to.be.true;
+    });
+
+    it('Creates new iOS simulator', async () => {
+        const runtimesMock = stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'enumerateRuntimes');
+        runtimesMock.resolves([
+            {
+                bundlePath:
+                    '/Library/Developer/CoreSimulator/Volumes/iOS_21F79/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.5.simruntime',
+                identifier: 'com.apple.CoreSimulator.SimRuntime.iOS-18-5',
+                isAvailable: true,
+                isInternal: false,
+                name: 'iOS 18.5',
+                platform: 'iOS',
+                runtimeRoot:
+                    '/Library/Developer/CoreSimulator/Volumes/iOS_21F79/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS 18.5.simruntime/Contents/Resources/RuntimeRoot',
+                version: '18.5',
+                supportedDeviceTypes: [
+                    {
+                        bundlePath: '/Library/Developer/CoreSimulator/Profiles/DeviceTypes/iPhone 16.simdevicetype',
+                        identifier: 'com.apple.CoreSimulator.SimDeviceType.iPhone-16',
+                        name: 'iPhone 16',
+                        productFamily: 'iPhone'
+                    }
+                ]
+            } as AppleRuntime
+        ]);
+
+        const createSimMock = stubMethod($$.SANDBOX, IOSUtils, 'createNewDevice');
+        createSimMock.resolves('TestUDID');
+
+        await Create.run(['-p', 'ios', '-n', deviceName, '-d', iOSDeviceType]);
+
+        expect(executeSetupMock.called).to.be.true;
+        expect(runtimesMock.called).to.be.true;
+        expect(createSimMock.calledWith(deviceName, iOSDeviceType, 'iOS-18-5', sinon.match.any)).to.be.true;
     });
 
     it('Logger must be initialized and invoked', async () => {

--- a/test/unit/cli/commands/force/lightning/local/device/create.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/create.test.ts
@@ -9,7 +9,15 @@ import sinon from 'sinon';
 import { Logger } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
-import { AndroidPackage, AndroidUtils, AppleDeviceManager, AppleRuntime, IOSUtils, RequirementProcessor, Version } from '@salesforce/lwc-dev-mobile-core';
+import {
+    AndroidPackage,
+    AndroidUtils,
+    AppleDeviceManager,
+    AppleRuntime,
+    IOSUtils,
+    RequirementProcessor,
+    Version
+} from '@salesforce/lwc-dev-mobile-core';
 import { expect } from 'chai';
 import { Create } from '../../../../../../../../src/cli/commands/force/lightning/local/device/create.js';
 
@@ -43,7 +51,7 @@ describe('Device Create Tests', () => {
                 'Google APIs Intel x86 Atom_64 System Image',
                 `system-images/${androidApi}/${androidImage}/${androidABI}/`
             )
-        )
+        );
 
         const createAvdMock = stubMethod($$.SANDBOX, AndroidUtils, 'createNewVirtualDevice');
         createAvdMock.resolves();
@@ -52,7 +60,16 @@ describe('Device Create Tests', () => {
 
         expect(executeSetupMock.called).to.be.true;
         expect(emulatorImagesMock.called).to.be.true;
-        expect(createAvdMock.calledWith(deviceName, androidImage, androidApi, androidDeviceType, androidABI, sinon.match.any)).to.be.true;
+        expect(
+            createAvdMock.calledWith(
+                deviceName,
+                androidImage,
+                androidApi,
+                androidDeviceType,
+                androidABI,
+                sinon.match.any
+            )
+        ).to.be.true;
     });
 
     it('Creates new iOS simulator', async () => {

--- a/test/unit/cli/commands/force/lightning/local/device/list.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/list.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { Logger } from '@salesforce/core';
+import { TestContext } from '@salesforce/core/testSetup';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { AndroidDevice, AndroidDeviceManager, AndroidOSType, AppleDevice, AppleDeviceManager, AppleOSType, DeviceType, IOSUtils, Version } from '@salesforce/lwc-dev-mobile-core';
+import { expect } from 'chai';
+import { List } from '../../../../../../../../src/cli/commands/force/lightning/local/device/list.js';
+
+describe('Device List Tests', () => {
+    const $$ = new TestContext();
+
+    const androidDevice = new AndroidDevice(
+        'Pixel_5_API_35',
+        'Pixel 5 API 35',
+        DeviceType.mobile,
+        AndroidOSType.googleAPIs,
+        new Version(35, 0, 0),
+        false
+    );
+
+    const appleDevice = new AppleDevice(
+        '3627EBD5-E9EC-4EC4-8E89-C6A0232C920D',
+        'iPhone 16',
+        DeviceType.mobile,
+        AppleOSType.iOS,
+        new Version(18, 5, 0)
+    )
+
+    afterEach(() => {
+        $$.restore();
+    });
+
+    it('Lists Android emulators', async () => {
+        const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([androidDevice]);
+        await List.run(['-p', 'android']);
+        expect(enumerateMock.called).to.be.true;
+    });
+
+    it('Lists iOS simulators', async () => {
+        const enumerateMock = stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'enumerateDevices').resolves([appleDevice]);
+        await List.run(['-p', 'ios']);
+        expect(enumerateMock.called).to.be.true;
+    });
+
+    it('Logger must be initialized and invoked', async () => {
+        const loggerMock = stubMethod($$.SANDBOX, Logger.prototype, 'info');
+        stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'enumerateRuntimes').resolves([]);
+        stubMethod($$.SANDBOX, IOSUtils, 'createNewDevice').resolves('TestUDID');
+        await List.run(['-p', 'ios']);
+        expect(loggerMock.called).to.be.true;
+    });
+
+    it('Messages folder should be loaded', async () => {
+        expect(!List.summary).to.be.false;
+    });
+});

--- a/test/unit/cli/commands/force/lightning/local/device/list.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/list.test.ts
@@ -8,7 +8,17 @@
 import { Logger } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
-import { AndroidDevice, AndroidDeviceManager, AndroidOSType, AppleDevice, AppleDeviceManager, AppleOSType, DeviceType, IOSUtils, Version } from '@salesforce/lwc-dev-mobile-core';
+import {
+    AndroidDevice,
+    AndroidDeviceManager,
+    AndroidOSType,
+    AppleDevice,
+    AppleDeviceManager,
+    AppleOSType,
+    DeviceType,
+    IOSUtils,
+    Version
+} from '@salesforce/lwc-dev-mobile-core';
 import { expect } from 'chai';
 import { List } from '../../../../../../../../src/cli/commands/force/lightning/local/device/list.js';
 
@@ -30,20 +40,24 @@ describe('Device List Tests', () => {
         DeviceType.mobile,
         AppleOSType.iOS,
         new Version(18, 5, 0)
-    )
+    );
 
     afterEach(() => {
         $$.restore();
     });
 
     it('Lists Android emulators', async () => {
-        const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([androidDevice]);
+        const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([
+            androidDevice
+        ]);
         await List.run(['-p', 'android']);
         expect(enumerateMock.called).to.be.true;
     });
 
     it('Lists iOS simulators', async () => {
-        const enumerateMock = stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'enumerateDevices').resolves([appleDevice]);
+        const enumerateMock = stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'enumerateDevices').resolves([
+            appleDevice
+        ]);
         await List.run(['-p', 'ios']);
         expect(enumerateMock.called).to.be.true;
     });

--- a/test/unit/cli/commands/force/lightning/local/device/start.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/start.test.ts
@@ -9,7 +9,18 @@ import sinon from 'sinon';
 import { Logger } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
-import { AndroidDevice, AndroidDeviceManager, AndroidOSType, AppleDevice, AppleDeviceManager, AppleOSType, BootMode, DeviceType, RequirementProcessor, Version } from '@salesforce/lwc-dev-mobile-core';
+import {
+    AndroidDevice,
+    AndroidDeviceManager,
+    AndroidOSType,
+    AppleDevice,
+    AppleDeviceManager,
+    AppleOSType,
+    BootMode,
+    DeviceType,
+    RequirementProcessor,
+    Version
+} from '@salesforce/lwc-dev-mobile-core';
 import { expect } from 'chai';
 import { Start } from '../../../../../../../../src/cli/commands/force/lightning/local/device/start.js';
 
@@ -31,7 +42,7 @@ describe('Device Start Tests', () => {
         DeviceType.mobile,
         AppleOSType.iOS,
         new Version(18, 5, 0)
-    )
+    );
 
     let executeSetupMock: sinon.SinonStub<any[], any>;
 
@@ -45,7 +56,9 @@ describe('Device Start Tests', () => {
     });
 
     it('Starts up Android emulator', async () => {
-        const getDeviceMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(androidDevice);
+        const getDeviceMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(
+            androidDevice
+        );
         const bootMock = stubMethod($$.SANDBOX, AndroidDevice.prototype, 'boot').resolves();
         await Start.run(['-p', 'android', '-t', androidDevice.name, '-w']);
 
@@ -63,7 +76,6 @@ describe('Device Start Tests', () => {
         expect(getDeviceMock.called).to.be.true;
         expect(bootMock.calledWith(true)).to.be.true;
     });
-
 
     it('Logger must be initialized and invoked', async () => {
         const loggerMock = stubMethod($$.SANDBOX, Logger.prototype, 'info');

--- a/test/unit/cli/commands/force/lightning/local/device/start.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/start.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import sinon from 'sinon';
+import { Logger } from '@salesforce/core';
+import { TestContext } from '@salesforce/core/testSetup';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { AndroidDevice, AndroidDeviceManager, AndroidOSType, AppleDevice, AppleDeviceManager, AppleOSType, BootMode, DeviceType, RequirementProcessor, Version } from '@salesforce/lwc-dev-mobile-core';
+import { expect } from 'chai';
+import { Start } from '../../../../../../../../src/cli/commands/force/lightning/local/device/start.js';
+
+describe('Device Start Tests', () => {
+    const $$ = new TestContext();
+
+    const androidDevice = new AndroidDevice(
+        'Pixel_5_API_35',
+        'Pixel 5 API 35',
+        DeviceType.mobile,
+        AndroidOSType.googleAPIs,
+        new Version(35, 0, 0),
+        false
+    );
+
+    const appleDevice = new AppleDevice(
+        '3627EBD5-E9EC-4EC4-8E89-C6A0232C920D',
+        'iPhone 16',
+        DeviceType.mobile,
+        AppleOSType.iOS,
+        new Version(18, 5, 0)
+    )
+
+    let executeSetupMock: sinon.SinonStub<any[], any>;
+
+    beforeEach(() => {
+        executeSetupMock = stubMethod($$.SANDBOX, RequirementProcessor, 'execute');
+        executeSetupMock.resolves(Promise.resolve());
+    });
+
+    afterEach(() => {
+        $$.restore();
+    });
+
+    it('Starts up Android emulator', async () => {
+        const getDeviceMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(androidDevice);
+        const bootMock = stubMethod($$.SANDBOX, AndroidDevice.prototype, 'boot').resolves();
+        await Start.run(['-p', 'android', '-t', androidDevice.name, '-w']);
+
+        expect(executeSetupMock.called).to.be.true;
+        expect(getDeviceMock.called).to.be.true;
+        expect(bootMock.calledWith(true, BootMode.systemWritableMandatory)).to.be.true;
+    });
+
+    it('Starts up iOS simulator', async () => {
+        const getDeviceMock = stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'getDevice').resolves(appleDevice);
+        const bootMock = stubMethod($$.SANDBOX, AppleDevice.prototype, 'boot').resolves();
+        await Start.run(['-p', 'ios', '-t', appleDevice.name]);
+
+        expect(executeSetupMock.called).to.be.true;
+        expect(getDeviceMock.called).to.be.true;
+        expect(bootMock.calledWith(true)).to.be.true;
+    });
+
+
+    it('Logger must be initialized and invoked', async () => {
+        const loggerMock = stubMethod($$.SANDBOX, Logger.prototype, 'info');
+        stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'getDevice').resolves(appleDevice);
+        stubMethod($$.SANDBOX, AppleDevice.prototype, 'boot').resolves();
+        await Start.run(['-p', 'ios', '-t', appleDevice.name]);
+        expect(loggerMock.called).to.be.true;
+    });
+
+    it('Messages folder should be loaded', async () => {
+        expect(!Start.summary).to.be.false;
+    });
+});

--- a/test/unit/cli/commands/force/lightning/local/setup.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/setup.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { TestContext } from '@salesforce/core/testSetup';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { RequirementProcessor } from '@salesforce/lwc-dev-mobile-core';
+import { expect } from 'chai';
+import { Setup } from '../../../../../../../src/cli/commands/force/lightning/local/setup.js';
+
+describe('Setup Tests', () => {
+    const $$ = new TestContext();
+    let executeSetupMock: sinon.SinonStub<any[], any>;
+
+    beforeEach(() => {
+        executeSetupMock = stubMethod($$.SANDBOX, RequirementProcessor, 'execute');
+        executeSetupMock.resolves(Promise.resolve());
+    });
+
+    afterEach(() => {
+        $$.restore();
+    });
+
+    it('Should route to Setup in lwc-dev-mobile-core', async () => {
+        await Setup.run(['-p', 'ios']);
+        expect(executeSetupMock.called).to.be.true;
+    });
+});

--- a/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/configure.test.ts
+++ b/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/configure.test.ts
@@ -9,7 +9,18 @@ import sinon from 'sinon';
 import { Logger, Messages } from '@salesforce/core';
 import { TestContext } from '@salesforce/core/testSetup';
 import { stubMethod } from '@salesforce/ts-sinon';
-import { AndroidDevice, AndroidDeviceManager, AndroidOSType, AppleDevice, AppleDeviceManager, AppleOSType, CommonUtils, DeviceType, RequirementProcessor, Version } from '@salesforce/lwc-dev-mobile-core';
+import {
+    AndroidDevice,
+    AndroidDeviceManager,
+    AndroidOSType,
+    AppleDevice,
+    AppleDeviceManager,
+    AppleOSType,
+    CommonUtils,
+    DeviceType,
+    RequirementProcessor,
+    Version
+} from '@salesforce/lwc-dev-mobile-core';
 import { expect } from 'chai';
 import { Configure } from '../../../../../../../../../../src/cli/commands/force/lightning/lwc/test/ui/mobile/configure.js';
 
@@ -34,7 +45,7 @@ describe('Mobile UI Test Configuration Tests', () => {
         DeviceType.mobile,
         AppleOSType.iOS,
         new Version(18, 5, 0)
-    )
+    );
 
     let executeSetupMock: sinon.SinonStub<any[], any>;
 
@@ -128,7 +139,9 @@ describe('Mobile UI Test Configuration Tests', () => {
                 'com.example.android.myApp'
             ]);
         } catch (error) {
-            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.notFound.device', ['Pixel 5 API 33']));
+            expect(error)
+                .to.be.an('error')
+                .with.property('message', messages.getMessage('error.notFound.device', ['Pixel 5 API 33']));
         }
     });
 
@@ -155,7 +168,9 @@ describe('Mobile UI Test Configuration Tests', () => {
                 '/path/to/my.app'
             ]);
         } catch (error) {
-            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.notFound.device', ['iPhone 16']));
+            expect(error)
+                .to.be.an('error')
+                .with.property('message', messages.getMessage('error.notFound.device', ['iPhone 16']));
         }
     });
 
@@ -196,14 +211,7 @@ describe('Mobile UI Test Configuration Tests', () => {
         const createTextFileMock = stubMethod($$.SANDBOX, CommonUtils, 'createTextFile');
         createTextFileMock.resolves();
 
-        await Configure.run([
-            '-p',
-            'ios',
-            '-d',
-            appleDevice.name,
-            '--bundlepath',
-            '/path/to/my.app',
-        ]);
+        await Configure.run(['-p', 'ios', '-d', appleDevice.name, '--bundlepath', '/path/to/my.app']);
 
         expect(executeSetupMock.called).to.be.true;
 
@@ -251,7 +259,6 @@ describe('Mobile UI Test Configuration Tests', () => {
         expect(args[1]).to.contain('"appium:appActivity": ".MainActivity"');
         expect(args[1]).to.contain('"appium:appPackage": "com.example.android.myApp"');
     });
-
 
     it('Logger must be initialized and invoked', async () => {
         const loggerMock = stubMethod($$.SANDBOX, Logger.prototype, 'info');

--- a/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/configure.test.ts
+++ b/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/configure.test.ts
@@ -262,7 +262,7 @@ describe('Mobile UI Test Configuration Tests', () => {
 
     it('Logger must be initialized and invoked', async () => {
         const loggerMock = stubMethod($$.SANDBOX, Logger.prototype, 'info');
-        stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(androidDevice);
+        stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'getDevice').resolves(appleDevice);
         stubMethod($$.SANDBOX, CommonUtils, 'createTextFile').resolves();
         await Configure.run(['-p', 'ios', '-d', 'iPhone 16']);
         expect(loggerMock.called).to.be.true;

--- a/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/configure.test.ts
+++ b/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/configure.test.ts
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import sinon from 'sinon';
+import { Logger, Messages } from '@salesforce/core';
+import { TestContext } from '@salesforce/core/testSetup';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { AndroidDevice, AndroidDeviceManager, AndroidOSType, AppleDevice, AppleDeviceManager, AppleOSType, CommonUtils, DeviceType, RequirementProcessor, Version } from '@salesforce/lwc-dev-mobile-core';
+import { expect } from 'chai';
+import { Configure } from '../../../../../../../../../../src/cli/commands/force/lightning/lwc/test/ui/mobile/configure.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+
+describe('Mobile UI Test Configuration Tests', () => {
+    const messages = Messages.loadMessages('@salesforce/lwc-dev-mobile', 'test-ui-mobile-configure');
+    const $$ = new TestContext();
+
+    const androidDevice = new AndroidDevice(
+        'Pixel_5_API_35',
+        'Pixel 5 API 35',
+        DeviceType.mobile,
+        AndroidOSType.googleAPIs,
+        new Version(35, 0, 0),
+        false
+    );
+
+    const appleDevice = new AppleDevice(
+        '3627EBD5-E9EC-4EC4-8E89-C6A0232C920D',
+        'iPhone 16',
+        DeviceType.mobile,
+        AppleOSType.iOS,
+        new Version(18, 5, 0)
+    )
+
+    let executeSetupMock: sinon.SinonStub<any[], any>;
+
+    beforeEach(() => {
+        executeSetupMock = stubMethod($$.SANDBOX, RequirementProcessor, 'execute');
+        executeSetupMock.resolves(Promise.resolve());
+    });
+
+    afterEach(() => {
+        $$.restore();
+    });
+
+    it('Fails if appActivity is missing when targeting Android', async () => {
+        try {
+            await Configure.run([
+                '-p',
+                'android',
+                '-d',
+                'Pixel 5 API 33',
+                '--output',
+                './wdio.conf.js',
+                '--testframework',
+                'jasmine',
+                '--port',
+                '4723',
+                '--baseurl',
+                'http://localhost',
+                '--injectionconfigs',
+                './myPageObjects.config.json',
+                '--bundlepath',
+                '/path/to/my.apk',
+                '--apppackage',
+                'com.example.android.myApp'
+            ]);
+        } catch (error) {
+            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.invalid.appActivity'));
+        }
+    });
+
+    it('Fails if appPackage is missing when targeting Android', async () => {
+        try {
+            await Configure.run([
+                '-p',
+                'android',
+                '-d',
+                'Pixel 5 API 33',
+                '--output',
+                './wdio.conf.js',
+                '--testframework',
+                'jasmine',
+                '--port',
+                '4723',
+                '--baseurl',
+                'http://localhost',
+                '--injectionconfigs',
+                './myPageObjects.config.json',
+                '--bundlepath',
+                '/path/to/my.apk',
+                '--appactivity',
+                '.MainActivity'
+            ]);
+        } catch (error) {
+            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.invalid.appPackage'));
+        }
+    });
+
+    it('Fails when emulator is not found when targeting Android', async () => {
+        stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(undefined);
+
+        try {
+            await Configure.run([
+                '-p',
+                'android',
+                '-d',
+                'Pixel 5 API 33',
+                '--output',
+                './wdio.conf.js',
+                '--testframework',
+                'jasmine',
+                '--port',
+                '4723',
+                '--baseurl',
+                'http://localhost',
+                '--injectionconfigs',
+                './myPageObjects.config.json',
+                '--bundlepath',
+                '/path/to/my.apk',
+                '--appactivity',
+                '.MainActivity',
+                '--apppackage',
+                'com.example.android.myApp'
+            ]);
+        } catch (error) {
+            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.notFound.device', ['Pixel 5 API 33']));
+        }
+    });
+
+    it('Fails when simulator is not found when targeting iOS', async () => {
+        stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'getDevice').resolves(undefined);
+
+        try {
+            await Configure.run([
+                '-p',
+                'ios',
+                '-d',
+                'iPhone 16',
+                '--output',
+                './wdio.conf.js',
+                '--testframework',
+                'jasmine',
+                '--port',
+                '4723',
+                '--baseurl',
+                'http://localhost',
+                '--injectionconfigs',
+                './myPageObjects.config.json',
+                '--bundlepath',
+                '/path/to/my.app'
+            ]);
+        } catch (error) {
+            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.notFound.device', ['iPhone 16']));
+        }
+    });
+
+    it('Assigns default flag values', async () => {
+        stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(androidDevice);
+
+        const createTextFileMock = stubMethod($$.SANDBOX, CommonUtils, 'createTextFile');
+        createTextFileMock.resolves();
+
+        await Configure.run([
+            '-p',
+            'android',
+            '-d',
+            androidDevice.name,
+            '--appactivity',
+            '.MainActivity',
+            '--apppackage',
+            'com.example.android.myApp'
+        ]);
+
+        const args = createTextFileMock.getCall(0).args;
+        expect(args[0]).to.be.equal(Configure.defaultOutputFile);
+        expect(args[1]).to.contain('"appium:platformName": "Android"');
+        expect(args[1]).to.contain('"appium:automationName": "UiAutomator2"');
+        expect(args[1]).to.contain('"appium:app": ""');
+        expect(args[1]).to.contain('"appium:appActivity": ".MainActivity"');
+        expect(args[1]).to.contain('"appium:appPackage": "com.example.android.myApp"');
+        expect(args[1]).to.contain(`"appium:avd": "${androidDevice.name}"`);
+        expect(args[1]).to.contain(`"framework": "${Configure.supportedTestFrameworks[0]}"`);
+        expect(args[1]).not.to.contain('"port":');
+        expect(args[1]).to.contain(`"baseUrl": "${Configure.defaultTestRunnerBaseUrl}"`);
+        expect(args[1]).to.contain('"injectionConfigs": []');
+    });
+
+    it('Correct content is in config file - iOS', async () => {
+        stubMethod($$.SANDBOX, AppleDeviceManager.prototype, 'getDevice').resolves(appleDevice);
+
+        const createTextFileMock = stubMethod($$.SANDBOX, CommonUtils, 'createTextFile');
+        createTextFileMock.resolves();
+
+        await Configure.run([
+            '-p',
+            'ios',
+            '-d',
+            appleDevice.name,
+            '--bundlepath',
+            '/path/to/my.app',
+        ]);
+
+        expect(executeSetupMock.called).to.be.true;
+
+        const args = createTextFileMock.getCall(0).args;
+        expect(args[0]).to.be.equal(Configure.defaultOutputFile);
+        expect(args[1]).not.to.contain('"port":');
+        expect(args[1]).to.contain(`"baseUrl": "${Configure.defaultTestRunnerBaseUrl}"`);
+        expect(args[1]).to.contain(`"framework": "${Configure.supportedTestFrameworks[0]}"`);
+        expect(args[1]).to.contain('"appium:platformName": "iOS"');
+        expect(args[1]).to.contain('"appium:automationName": "XCUITest"');
+        expect(args[1]).to.contain(`"appium:udid": "${appleDevice.id}"`);
+        expect(args[1]).to.contain('"appium:app": "/path/to/my.app"');
+    });
+
+    it('Correct content is in config file - Android', async () => {
+        stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(androidDevice);
+
+        const createTextFileMock = stubMethod($$.SANDBOX, CommonUtils, 'createTextFile');
+        createTextFileMock.resolves();
+
+        await Configure.run([
+            '-p',
+            'android',
+            '-d',
+            androidDevice.name,
+            '--bundlepath',
+            '/path/to/my.apk',
+            '--appactivity',
+            '.MainActivity',
+            '--apppackage',
+            'com.example.android.myApp'
+        ]);
+
+        expect(executeSetupMock.called).to.be.true;
+
+        const args = createTextFileMock.getCall(0).args;
+        expect(args[0]).to.be.equal(Configure.defaultOutputFile);
+        expect(args[1]).not.to.contain('"port":');
+        expect(args[1]).to.contain(`"baseUrl": "${Configure.defaultTestRunnerBaseUrl}"`);
+        expect(args[1]).to.contain(`"framework": "${Configure.supportedTestFrameworks[0]}"`);
+        expect(args[1]).to.contain('"appium:platformName": "Android"');
+        expect(args[1]).to.contain('"appium:automationName": "UiAutomator2"');
+        expect(args[1]).to.contain(`"appium:avd": "${androidDevice.name}"`);
+        expect(args[1]).to.contain('"appium:app": "/path/to/my.apk"');
+        expect(args[1]).to.contain('"appium:appActivity": ".MainActivity"');
+        expect(args[1]).to.contain('"appium:appPackage": "com.example.android.myApp"');
+    });
+
+
+    it('Logger must be initialized and invoked', async () => {
+        const loggerMock = stubMethod($$.SANDBOX, Logger.prototype, 'info');
+        stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'getDevice').resolves(androidDevice);
+        stubMethod($$.SANDBOX, CommonUtils, 'createTextFile').resolves();
+        await Configure.run(['-p', 'ios', '-d', 'iPhone 16']);
+        expect(loggerMock.called).to.be.true;
+    });
+
+    it('Messages folder should be loaded', async () => {
+        expect(!Configure.summary).to.be.false;
+    });
+});

--- a/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/run.test.ts
+++ b/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/run.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import fs from 'node:fs';
+import { Logger, Messages } from '@salesforce/core';
+import { TestContext } from '@salesforce/core/testSetup';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { CommonUtils } from '@salesforce/lwc-dev-mobile-core';
+import { expect } from 'chai';
+import { Run } from '../../../../../../../../../../src/cli/commands/force/lightning/lwc/test/ui/mobile/run.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+
+describe('Mobile UI Test Run Tests', () => {
+    const messages = Messages.loadMessages('@salesforce/lwc-dev-mobile', 'test-ui-mobile-run');
+    const $$ = new TestContext();
+
+    afterEach(() => {
+        $$.restore();
+    });
+
+    it('Fails if config file is does not exist', async () => {
+        try {
+            await Run.run(['--config', 'blah']);
+        } catch (error) {
+            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.configFile.pathInvalid', ['blah']));
+        }
+    });
+
+    it('Fails if spec file is does not exist', async () => {
+        const npxWdioCommandMock = stubMethod($$.SANDBOX, fs, 'existsSync');
+        npxWdioCommandMock.onCall(0).returns(true);
+        npxWdioCommandMock.onCall(1).returns(false);
+        try {
+            await Run.run(['--config', './wdio.conf.js', '--spec', 'blah']);
+        } catch (error) {
+            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.spec.pathInvalid', ['blah']));
+        }
+    });
+
+    it('Calls the correct npx wdio command with a test spec', async () => {
+        const quote = process.platform === 'win32' ? '"' : "'";
+        const config = 'wdio.config.js';
+        const spec = 'mytest.spec.js';
+
+        stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
+        stubMethod($$.SANDBOX, CommonUtils, 'enumerateFiles').returns([spec]);
+        const npxWdioCommandMock = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync');
+        npxWdioCommandMock.resolves({ stdout: '', stderr: '' });
+
+        await Run.run(['--config', config, '--spec', spec]);
+
+        expect(npxWdioCommandMock.calledWith(
+            'npx',
+            [
+                '--no-install',
+                'wdio',
+                `${quote}${config}${quote}`,
+                '--spec',
+                `${quote}${spec}${quote}`
+            ],
+            ['inherit', 'inherit', 'inherit']
+        )).to.be.true;
+    });
+
+
+    it('Catches error when npx wdio command fails', async () => {
+        const errorMessage = 'UTAM test run failed';
+
+        stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
+        stubMethod($$.SANDBOX, CommonUtils, 'enumerateFiles').returns([]);
+        const npxWdioCommandMock = stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync');
+        npxWdioCommandMock.rejects(new Error(errorMessage));
+
+        try {
+            await Run.run(['--config', 'wdio.config.js', '--spec', 'mytest.spec.js']);
+        } catch (error) {
+            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.unexpected', [errorMessage]));
+        }
+    });
+
+    it('Logger must be initialized and invoked', async () => {
+        const loggerMock = stubMethod($$.SANDBOX, Logger.prototype, 'info');
+        stubMethod($$.SANDBOX, fs, 'existsSync').returns(true);
+        stubMethod($$.SANDBOX, CommonUtils, 'enumerateFiles').returns([]);
+        stubMethod($$.SANDBOX, CommonUtils, 'spawnCommandAsync').resolves();
+        await Run.run(['--config', 'wdio.config.js', '--spec', 'mytest.spec.js']);
+        expect(loggerMock.called).to.be.true;
+    });
+
+    it('Messages folder should be loaded', async () => {
+        expect(!Run.summary).to.be.false;
+    });
+});

--- a/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/run.test.ts
+++ b/test/unit/cli/commands/force/lightning/lwc/test/ui/mobile/run.test.ts
@@ -27,7 +27,9 @@ describe('Mobile UI Test Run Tests', () => {
         try {
             await Run.run(['--config', 'blah']);
         } catch (error) {
-            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.configFile.pathInvalid', ['blah']));
+            expect(error)
+                .to.be.an('error')
+                .with.property('message', messages.getMessage('error.configFile.pathInvalid', ['blah']));
         }
     });
 
@@ -38,7 +40,9 @@ describe('Mobile UI Test Run Tests', () => {
         try {
             await Run.run(['--config', './wdio.conf.js', '--spec', 'blah']);
         } catch (error) {
-            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.spec.pathInvalid', ['blah']));
+            expect(error)
+                .to.be.an('error')
+                .with.property('message', messages.getMessage('error.spec.pathInvalid', ['blah']));
         }
     });
 
@@ -54,19 +58,14 @@ describe('Mobile UI Test Run Tests', () => {
 
         await Run.run(['--config', config, '--spec', spec]);
 
-        expect(npxWdioCommandMock.calledWith(
-            'npx',
-            [
-                '--no-install',
-                'wdio',
-                `${quote}${config}${quote}`,
-                '--spec',
-                `${quote}${spec}${quote}`
-            ],
-            ['inherit', 'inherit', 'inherit']
-        )).to.be.true;
+        expect(
+            npxWdioCommandMock.calledWith(
+                'npx',
+                ['--no-install', 'wdio', `${quote}${config}${quote}`, '--spec', `${quote}${spec}${quote}`],
+                ['inherit', 'inherit', 'inherit']
+            )
+        ).to.be.true;
     });
-
 
     it('Catches error when npx wdio command fails', async () => {
         const errorMessage = 'UTAM test run failed';
@@ -79,7 +78,9 @@ describe('Mobile UI Test Run Tests', () => {
         try {
             await Run.run(['--config', 'wdio.config.js', '--spec', 'mytest.spec.js']);
         } catch (error) {
-            expect(error).to.be.an('error').with.property('message', messages.getMessage('error.unexpected', [errorMessage]));
+            expect(error)
+                .to.be.an('error')
+                .with.property('message', messages.getMessage('error.unexpected', [errorMessage]));
         }
     });
 


### PR DESCRIPTION
Migrating the old tests from jest to mocha. You can refer to [here](https://github.com/forcedotcom/lwc-dev-mobile/tree/main/src/cli/commands/force/lightning) to take a looks at the old tests (in various subfolders).