### PR TITLE
feat: add ostype filter for device create command

### DIFF
--- a/messages/device-list.md
+++ b/messages/device-list.md
@@ -4,7 +4,7 @@ List the available virtual mobile devices for Lightning Web Component developmen
 
 # flags.ostype.description
 
-Filter Android devices by operating system type. Use 'default' to show only default OS type devices, or 'all' to show all devices. This flag applies only to Android devices.
+Filter by OS type. Options: 'default' (restricts to iOS or google_apis) or 'all'.
 
 # device.list.action
 

--- a/messages/device-list.md
+++ b/messages/device-list.md
@@ -18,4 +18,4 @@ generating list of supported devices
 
 - <%= config.bin %> <%= command.id %> -p ios
 - <%= config.bin %> <%= command.id %> -p android
-- <%= config.bin %> <%= command.id %> -p android --ostype default
+- <%= config.bin %> <%= command.id %> -p android --os-type default

--- a/messages/device-list.md
+++ b/messages/device-list.md
@@ -2,7 +2,7 @@
 
 List the available virtual mobile devices for Lightning Web Component development.
 
-# flags.ostype.description
+# flags.os-type.description
 
 Filter by OS type. Options: 'default' (restricts to iOS or google_apis) or 'all'.
 

--- a/messages/device-list.md
+++ b/messages/device-list.md
@@ -2,6 +2,10 @@
 
 List the available virtual mobile devices for Lightning Web Component development.
 
+# flags.ostype.description
+
+Filter Android devices by operating system type. Use 'default' to show only default OS type devices, or 'all' to show all devices. This flag applies only to Android devices.
+
 # device.list.action
 
 Device List
@@ -14,3 +18,4 @@ generating list of supported devices
 
 - <%= config.bin %> <%= command.id %> -p ios
 - <%= config.bin %> <%= command.id %> -p android
+- <%= config.bin %> <%= command.id %> -p android --ostype default

--- a/messages/device-list.md
+++ b/messages/device-list.md
@@ -4,7 +4,7 @@ List the available virtual mobile devices for Lightning Web Component developmen
 
 # flags.os-type.description
 
-Filter by OS type. Options: 'default' (restricts to iOS or google_apis) or 'all'.
+Filter devices by operating system type. Use 'default' to show only default OS type devices, or 'all' to show all devices.
 
 # device.list.action
 
@@ -18,4 +18,4 @@ generating list of supported devices
 
 - <%= config.bin %> <%= command.id %> -p ios
 - <%= config.bin %> <%= command.id %> -p android
-- <%= config.bin %> <%= command.id %> -p android --os-type default
+- <%= config.bin %> <%= command.id %> -p android -o default

--- a/package.json
+++ b/package.json
@@ -260,5 +260,6 @@
         }
     },
     "exports": "./dist/index.js",
-    "type": "module"
+    "type": "module",
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -260,6 +260,5 @@
         }
     },
     "exports": "./dist/index.js",
-    "type": "module",
-    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+    "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@salesforce/lwc-dev-mobile",
     "description": "Salesforce CLI plugin for mobile extensions to Local Development",
-    "version": "3.0.0-alpha.2",
+    "version": "3.0.0-alpha.3",
     "author": {
         "name": "Meisam Seyed Aliroteh",
         "email": "maliroteh@salesforce.com",

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -55,7 +55,7 @@ export class List extends BaseCommand {
         return this.flagValues.platform as string;
     }
 
-    private get ostype(): string | undefined {
+    private get ostype(): string {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         return this.flagValues['os-type'] as string;
     }

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -39,9 +39,10 @@ export class List extends BaseCommand {
         ...CommandLineUtils.createFlag(FlagsConfigType.PlatformFlag, true),
         'os-type': Flags.string({
             char: 'o',
-            description: messages.getMessage('flags.ostype.description'),
+            description: messages.getMessage('flags.os-type.description'),
             required: false,
-            options: ['default', 'all']
+            options: ['default', 'all'],
+            default: 'default'
         })
     };
 
@@ -56,7 +57,7 @@ export class List extends BaseCommand {
 
     private get ostype(): string | undefined {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        return this.flagValues['os-type'] as string | undefined;
+        return this.flagValues['os-type'] as string;
     }
 
     protected static getOutputSchema(): z.ZodTypeAny {

--- a/src/cli/commands/force/lightning/local/device/list.ts
+++ b/src/cli/commands/force/lightning/local/device/list.ts
@@ -42,8 +42,7 @@ export class List extends BaseCommand {
         ostype: Flags.string({
             description: messages.getMessage('flags.ostype.description'),
             required: false,
-            options: ['default', 'all'],
-            helpValue: 'default|all'
+            options: ['default', 'all']
         })
     };
 

--- a/test/unit/cli/commands/force/lightning/local/device/list.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/list.test.ts
@@ -18,6 +18,7 @@ import {
     CommonUtils,
     DeviceType,
     IOSUtils,
+    PlatformConfig,
     Version
 } from '@salesforce/lwc-dev-mobile-core';
 import { expect } from 'chai';
@@ -26,11 +27,20 @@ import { List } from '../../../../../../../../src/cli/commands/force/lightning/l
 describe('Device List Tests', () => {
     const $$ = new TestContext();
 
-    const androidDevice = new AndroidDevice(
+    const androidDeviceGoogleApi = new AndroidDevice(
         'Pixel_5_API_35',
         'Pixel 5 API 35',
         DeviceType.mobile,
         AndroidOSType.googleAPIs,
+        new Version(35, 0, 0),
+        false
+    );
+
+    const androidDeviceDefault = new AndroidDevice(
+        'Pixel_Default',
+        'Pixel Default',
+        DeviceType.mobile,
+        'default',
         new Version(35, 0, 0),
         false
     );
@@ -59,18 +69,55 @@ describe('Device List Tests', () => {
 
     it('Lists Android emulators for cli mode', async () => {
         const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([
-            androidDevice
+            androidDeviceGoogleApi
         ]);
         await List.run(['-p', 'android']);
 
         expect(enumerateMock.called).to.be.true;
         expect(startCliActionMock.called).to.be.true;
         expect(stopCliActionMock.called).to.be.true;
+
+        expect(enumerateMock.calledWith()).to.be.true;
+    });
+
+    it('Lists Android emulators with ostype flag set to default for cli mode', async () => {
+        const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([
+            androidDeviceDefault,
+            androidDeviceGoogleApi
+        ]);
+        await List.run(['-p', 'android', '--ostype', 'default']);
+
+        expect(enumerateMock.called).to.be.true;
+        expect(startCliActionMock.called).to.be.true;
+        expect(stopCliActionMock.called).to.be.true;
+
+        expect(
+            enumerateMock.calledWith([
+                {
+                    osType: 'default',
+                    minOSVersion: Version.from(PlatformConfig.androidConfig().minSupportedRuntime)!
+                }
+            ])
+        ).to.be.true;
+    });
+
+    it('Lists Android emulators with ostype flag set to all for cli mode', async () => {
+        const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([
+            androidDeviceDefault,
+            androidDeviceGoogleApi
+        ]);
+        await List.run(['-p', 'android', '--ostype', 'all']);
+
+        expect(enumerateMock.called).to.be.true;
+        expect(startCliActionMock.called).to.be.true;
+        expect(stopCliActionMock.called).to.be.true;
+
+        expect(enumerateMock.calledWith(null)).to.be.true;
     });
 
     it('Lists Android emulators for json mode', async () => {
         const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([
-            androidDevice
+            androidDeviceGoogleApi
         ]);
         await List.run(['-p', 'android', '--json']);
 

--- a/test/unit/cli/commands/force/lightning/local/device/list.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/list.test.ts
@@ -18,7 +18,6 @@ import {
     CommonUtils,
     DeviceType,
     IOSUtils,
-    PlatformConfig,
     Version
 } from '@salesforce/lwc-dev-mobile-core';
 import { expect } from 'chai';
@@ -32,15 +31,6 @@ describe('Device List Tests', () => {
         'Pixel 5 API 35',
         DeviceType.mobile,
         AndroidOSType.googleAPIs,
-        new Version(35, 0, 0),
-        false
-    );
-
-    const androidDeviceDefault = new AndroidDevice(
-        'Pixel_Default',
-        'Pixel Default',
-        DeviceType.mobile,
-        'default',
         new Version(35, 0, 0),
         false
     );
@@ -80,33 +70,24 @@ describe('Device List Tests', () => {
         expect(enumerateMock.calledWith()).to.be.true;
     });
 
-    it('Lists Android emulators with ostype flag set to default for cli mode', async () => {
+    it('Lists Android emulators with os-type flag set to default for cli mode', async () => {
         const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([
-            androidDeviceDefault,
             androidDeviceGoogleApi
         ]);
-        await List.run(['-p', 'android', '--ostype', 'default']);
+        await List.run(['-p', 'android', '--os-type', 'default']);
 
         expect(enumerateMock.called).to.be.true;
         expect(startCliActionMock.called).to.be.true;
         expect(stopCliActionMock.called).to.be.true;
 
-        expect(
-            enumerateMock.calledWith([
-                {
-                    osType: 'default',
-                    minOSVersion: Version.from(PlatformConfig.androidConfig().minSupportedRuntime)!
-                }
-            ])
-        ).to.be.true;
+        expect(enumerateMock.calledWith()).to.be.true;
     });
 
-    it('Lists Android emulators with ostype flag set to all for cli mode', async () => {
+    it('Lists Android emulators with os-type flag set to all for cli mode', async () => {
         const enumerateMock = stubMethod($$.SANDBOX, AndroidDeviceManager.prototype, 'enumerateDevices').resolves([
-            androidDeviceDefault,
             androidDeviceGoogleApi
         ]);
-        await List.run(['-p', 'android', '--ostype', 'all']);
+        await List.run(['-p', 'android', '--os-type', 'all']);
 
         expect(enumerateMock.called).to.be.true;
         expect(startCliActionMock.called).to.be.true;


### PR DESCRIPTION
Add optional `ostype` filter to `device list` command

The filter has following behaviors:

- `'all'`: Returns all available emulators.

- `'default'` or `Unspecified`: Preserves existing behavior by returning only google_apis emulators.