### PR TITLE
fix: enforce device requirement validation in --json mode

### DIFF
--- a/messages/device-create.md
+++ b/messages/device-create.md
@@ -50,6 +50,10 @@ virtual device '%s' of type '%s' created successfully
 
 error encountered
 
+# error:requirementCheckFailed
+
+Failed to meet the setup requirements for creating a virtual device.
+
 # examples
 
 - <%= config.bin %> <%= command.id %> -p ios -n MyNewVirtualDevice -d iPhone-16

--- a/src/cli/commands/force/lightning/local/device/create.ts
+++ b/src/cli/commands/force/lightning/local/device/create.ts
@@ -7,7 +7,7 @@
 
 import util from 'node:util';
 import { Flags } from '@salesforce/sf-plugins-core';
-import { Logger, Messages } from '@salesforce/core';
+import { Logger, Messages, SfError } from '@salesforce/core';
 import {
     AndroidDeviceManager,
     AndroidEnvironmentRequirements,
@@ -86,11 +86,24 @@ export class Create extends BaseCommand {
         ]);
 
         try {
-            // if not in JSON mode, execute the requirements and start the CLI action
-            if (!this.jsonEnabled()) {
-                await RequirementProcessor.execute(this.commandRequirements);
-                this.logger.info('Setup requirements met, continuing with Device Create');
+            // Always validate the requirements (including the device-type whitelist) regardless of
+            // --json. In JSON mode RequirementProcessor.execute does not throw on unmet requirements;
+            // it returns a result object, so we inspect it and throw. This prevents an automation
+            // wrapper that passes --json from silently bypassing device-type validation before an
+            // (untrusted) device name/type is forwarded to the device-creation primitives.
+            const jsonMode = this.jsonEnabled();
+            const requirementResult = await RequirementProcessor.execute(this.commandRequirements, jsonMode);
+            if (jsonMode && requirementResult && !requirementResult.hasMetAllRequirements) {
+                throw new SfError(
+                    messages.getMessage('error:requirementCheckFailed'),
+                    'lwc-dev-mobile',
+                    requirementResult.tests.filter((test) => !test.hasPassed).map((test) => test.message ?? test.title)
+                );
+            }
+            this.logger.info('Setup requirements met, continuing with Device Create');
 
+            // Only the interactive spinner is gated behind non-JSON mode.
+            if (!jsonMode) {
                 CommonUtils.startCliAction(
                     messages.getMessage('device.create.action'),
                     messages.getMessage('device.create.status', [this.deviceName, this.deviceType])

--- a/test/unit/cli/commands/force/lightning/local/device/create.test.ts
+++ b/test/unit/cli/commands/force/lightning/local/device/create.test.ts
@@ -140,7 +140,8 @@ describe('Device Create Tests', () => {
         expect(result).to.have.property('success', true);
         expect(result).to.have.property('device');
         expect(result).to.have.property('message');
-        expect(executeSetupMock.called).to.be.false;
+        // Requirement validation (device-type whitelist) must run even in JSON mode.
+        expect(executeSetupMock.called).to.be.true;
         expect(emulatorImagesMock.called).to.be.true;
         expect(
             createAvdMock.calledWith(
@@ -195,12 +196,43 @@ describe('Device Create Tests', () => {
         expect(result).to.have.property('success', true);
         expect(result).to.have.property('device');
         expect(result).to.have.property('message');
-        expect(executeSetupMock.called).to.be.false;
+        // Requirement validation (device-type whitelist) must run even in JSON mode.
+        expect(executeSetupMock.called).to.be.true;
         expect(runtimesMock.called).to.be.true;
         expect(createSimMock.calledWith(deviceName, iOSDeviceType, 'iOS-18-5', sinon.match.any)).to.be.true;
         expect(getDeviceMock.called).to.be.true;
         expect(startCliActionMock.called).to.be.false;
         expect(stopCliActionMock.called).to.be.false;
+    });
+
+    it('Enforces requirement validation in json mode and blocks device creation when unmet', async () => {
+        // Simulate RequirementProcessor.execute in JSON mode: it does not throw, it returns a
+        // result object. An unmet requirement (e.g. an invalid/unrecognized device type) must
+        // block the command from forwarding the untrusted device name/type to the create primitive.
+        executeSetupMock.resolves({
+            hasMetAllRequirements: false,
+            tests: [
+                {
+                    title: 'Validating specified device type',
+                    hasPassed: false,
+                    message: "Device type 'evil; rm -rf /' is invalid."
+                }
+            ]
+        });
+
+        const createAvdMock = stubMethod($$.SANDBOX, AndroidUtils, 'createNewVirtualDevice');
+        createAvdMock.resolves();
+
+        let thrown: Error | undefined;
+        try {
+            await Create.run(['-p', 'android', '-n', deviceName, '-d', 'evil; rm -rf /', '--json']);
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(executeSetupMock.called).to.be.true;
+        expect(thrown, 'expected the command to throw when requirements are unmet in json mode').to.be.an('error');
+        expect(createAvdMock.called, 'device creation must not run when requirements are unmet').to.be.false;
     });
 
     it('Logger must be initialized and invoked', async () => {


### PR DESCRIPTION
## What & Why

**W-23665289** (defense-in-depth half) — the `force:lightning:local:device:create` command gated `RequirementProcessor.execute` behind `!this.jsonEnabled()`. Those requirements include the **device-type whitelist** (`ValidDeviceTypeRequirement`) and the **device-name-availability** check. Under `--json`, an untrusted `deviceName` / `deviceType` reached `createNewVirtualDevice` / `createNewDevice` with no whitelist validation — the same values the companion core PR hardens at the process-spawn layer.

## Change

- Always call `RequirementProcessor.execute(this.commandRequirements, this.jsonEnabled())`, regardless of `--json`.
- `RequirementProcessor.execute` **returns** a result object (rather than throwing) in JSON mode, so the result's `hasMetAllRequirements` is inspected and an `SfError` is thrown, carrying each failed check's message as an action.
- Only the interactive spinner (`CommonUtils.startCliAction`) stays gated behind non-JSON mode.
- Added `error:requirementCheckFailed` message.

## Testing

- `yarn compile` ✓, `yarn lint` ✓, **105 tests passing**.
- Updated the two JSON-mode tests to assert requirement validation now runs.
- Added a security regression test: an invalid device type under `--json` throws and **blocks** device creation (`createNewVirtualDevice` is never called).

Companion PR: forcedotcom/lwc-dev-mobile-core#220 (hardens the shell-executing primitives themselves).